### PR TITLE
Add stages 8–11 with API endpoints and UI panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # God-Mode Ultra Flow Platform
 
-This repository hosts a full-stack platform implementing the God-Mode Ultra Flow vision. The system orchestrates generative design and construction workflows across eight stages:
+This repository hosts a full-stack platform implementing the God-Mode Ultra Flow vision. The system orchestrates generative design and construction workflows across twelve stages:
 
 0. Context ingestion
 1. Multi-agent variant generation
@@ -10,6 +10,10 @@ This repository hosts a full-stack platform implementing the God-Mode Ultra Flow
 5. Procurement & finance lock
 6. Fabrication & robotics mobilization
 7. Permit submission & construction start
+8. Live construction control
+9. Handover & operations
+10. Long-term optimization
+11. End-of-life circularity
 
 ## Stack
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,10 @@ from app.routers import (
     stage5,
     stage6,
     stage7,
+    stage8,
+    stage9,
+    stage10,
+    stage11,
 )
 
 app = FastAPI(title=settings.app_name)
@@ -21,6 +25,10 @@ app.include_router(stage4.router)
 app.include_router(stage5.router)
 app.include_router(stage6.router)
 app.include_router(stage7.router)
+app.include_router(stage8.router)
+app.include_router(stage9.router)
+app.include_router(stage10.router)
+app.include_router(stage11.router)
 
 
 @app.get("/")

--- a/backend/app/routers/stage10.py
+++ b/backend/app/routers/stage10.py
@@ -1,0 +1,15 @@
+from typing import Any, Dict
+from fastapi import APIRouter
+from app.services import stage10
+
+router = APIRouter(prefix="/stage10", tags=["Stage 10"])
+
+
+@router.post("/revenue")
+def revenue(payload: Dict[str, Any]):
+    return stage10.revenue(payload)
+
+
+@router.get("/resilience")
+def resilience():
+    return stage10.resilience()

--- a/backend/app/routers/stage11.py
+++ b/backend/app/routers/stage11.py
@@ -1,0 +1,15 @@
+from typing import Any, Dict
+from fastapi import APIRouter
+from app.services import stage11
+
+router = APIRouter(prefix="/stage11", tags=["Stage 11"])
+
+
+@router.post("/salvage")
+def salvage(payload: Dict[str, Any]):
+    return stage11.salvage(payload)
+
+
+@router.get("/match")
+def match():
+    return stage11.match()

--- a/backend/app/routers/stage8.py
+++ b/backend/app/routers/stage8.py
@@ -1,0 +1,15 @@
+from typing import Any, Dict
+from fastapi import APIRouter
+from app.services import stage8
+
+router = APIRouter(prefix="/stage8", tags=["Stage 8"])
+
+
+@router.post("/telemetry")
+def telemetry(payload: Dict[str, Any]):
+    return stage8.telemetry(payload)
+
+
+@router.get("/plan")
+def plan():
+    return stage8.plan()

--- a/backend/app/routers/stage9.py
+++ b/backend/app/routers/stage9.py
@@ -1,0 +1,15 @@
+from typing import Any, Dict
+from fastapi import APIRouter
+from app.services import stage9
+
+router = APIRouter(prefix="/stage9", tags=["Stage 9"])
+
+
+@router.post("/tuning")
+def tuning(payload: Dict[str, Any]):
+    return stage9.tuning(payload)
+
+
+@router.get("/wellness")
+def wellness():
+    return stage9.wellness()

--- a/backend/app/services/stage10.py
+++ b/backend/app/services/stage10.py
@@ -1,0 +1,14 @@
+from typing import Any, Dict, List
+from app.models.stage import StageResult
+
+revenue_records: List[Dict[str, Any]] = []
+resilience_metrics: Dict[str, Any] = {"score": 0}
+
+
+def revenue(data: Dict[str, Any]) -> StageResult:
+    revenue_records.append(data)
+    return StageResult(stage=10, status="revenue recorded", data={"count": len(revenue_records)})
+
+
+def resilience() -> StageResult:
+    return StageResult(stage=10, status="resilience metrics", data=resilience_metrics)

--- a/backend/app/services/stage11.py
+++ b/backend/app/services/stage11.py
@@ -1,0 +1,14 @@
+from typing import Any, Dict, List
+from app.models.stage import StageResult
+
+salvage_reports: List[Dict[str, Any]] = []
+match_state: Dict[str, Any] = {"matches": []}
+
+
+def salvage(data: Dict[str, Any]) -> StageResult:
+    salvage_reports.append(data)
+    return StageResult(stage=11, status="salvage recorded", data={"count": len(salvage_reports)})
+
+
+def match() -> StageResult:
+    return StageResult(stage=11, status="match info", data=match_state)

--- a/backend/app/services/stage8.py
+++ b/backend/app/services/stage8.py
@@ -1,0 +1,18 @@
+from typing import Any, Dict, List
+from app.models.stage import StageResult
+
+telemetry_log: List[Dict[str, Any]] = []
+current_plan: Dict[str, Any] = {"tasks": []}
+
+
+def telemetry(data: Dict[str, Any]) -> StageResult:
+    telemetry_log.append(data)
+    return StageResult(stage=8, status="telemetry received", data={"count": len(telemetry_log)})
+
+
+def plan() -> StageResult:
+    return StageResult(stage=8, status="current plan", data=current_plan)
+
+
+def scheduler_stub() -> None:
+    pass

--- a/backend/app/services/stage9.py
+++ b/backend/app/services/stage9.py
@@ -1,0 +1,14 @@
+from typing import Any, Dict, List
+from app.models.stage import StageResult
+
+tuning_events: List[Dict[str, Any]] = []
+wellness_state: Dict[str, Any] = {"status": "nominal"}
+
+
+def tuning(data: Dict[str, Any]) -> StageResult:
+    tuning_events.append(data)
+    return StageResult(stage=9, status="tuning received", data={"count": len(tuning_events)})
+
+
+def wellness() -> StageResult:
+    return StageResult(stage=9, status="wellness status", data=wellness_state)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,7 +5,8 @@ dependencies = [
     "fastapi",
     "uvicorn[standard]",
     "pydantic",
-    "httpx"
+    "httpx",
+    "pytest"
 ]
 
 [build-system]

--- a/backend/tests/test_stages8_11.py
+++ b/backend/tests/test_stages8_11.py
@@ -1,0 +1,44 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_stage8_endpoints():
+    res = client.get("/stage8/plan")
+    assert res.status_code == 200
+    assert res.json()["stage"] == 8
+    res = client.post("/stage8/telemetry", json={"value": 1})
+    assert res.status_code == 200
+    assert res.json()["stage"] == 8
+
+
+def test_stage9_endpoints():
+    res = client.get("/stage9/wellness")
+    assert res.status_code == 200
+    assert res.json()["stage"] == 9
+    res = client.post("/stage9/tuning", json={"value": 1})
+    assert res.status_code == 200
+    assert res.json()["stage"] == 9
+
+
+def test_stage10_endpoints():
+    res = client.get("/stage10/resilience")
+    assert res.status_code == 200
+    assert res.json()["stage"] == 10
+    res = client.post("/stage10/revenue", json={"value": 1})
+    assert res.status_code == 200
+    assert res.json()["stage"] == 10
+
+
+def test_stage11_endpoints():
+    res = client.get("/stage11/match")
+    assert res.status_code == 200
+    assert res.json()["stage"] == 11
+    res = client.post("/stage11/salvage", json={"value": 1})
+    assert res.status_code == 200
+    assert res.json()["stage"] == 11

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,10 @@ import Stage4 from './components/Stage4'
 import Stage5 from './components/Stage5'
 import Stage6 from './components/Stage6'
 import Stage7 from './components/Stage7'
+import Stage8 from './components/Stage8'
+import Stage9 from './components/Stage9'
+import Stage10 from './components/Stage10'
+import Stage11 from './components/Stage11'
 
 export default function App() {
   return (
@@ -19,6 +23,10 @@ export default function App() {
       <Stage5 />
       <Stage6 />
       <Stage7 />
+      <Stage8 />
+      <Stage9 />
+      <Stage10 />
+      <Stage11 />
     </div>
   )
 }

--- a/frontend/src/components/Stage10.tsx
+++ b/frontend/src/components/Stage10.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react'
+import { getStagePath, postStagePath } from '../lib/api'
+
+export default function Stage10() {
+  const [resilience, setResilience] = useState<any>(null)
+  const [revenueRes, setRevenueRes] = useState<any>(null)
+  const [input, setInput] = useState('')
+
+  const fetchResilience = async () => setResilience(await getStagePath(10, 'resilience'))
+  const sendRevenue = async () => {
+    setRevenueRes(await postStagePath(10, 'revenue', { value: input }))
+    setInput('')
+  }
+
+  return (
+    <div className="p-2 border rounded mb-2">
+      <h2 className="font-bold">Stage 10</h2>
+      <div className="flex space-x-2 mb-2">
+        <button className="bg-blue-500 text-white px-2 py-1" onClick={fetchResilience}>Get Resilience</button>
+        <input className="border p-1 flex-1" value={input} onChange={e => setInput(e.target.value)} />
+        <button className="bg-green-500 text-white px-2 py-1" onClick={sendRevenue}>Send Revenue</button>
+      </div>
+      {resilience && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(resilience, null, 2)}</pre>}
+      {revenueRes && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(revenueRes, null, 2)}</pre>}
+    </div>
+  )
+}

--- a/frontend/src/components/Stage11.tsx
+++ b/frontend/src/components/Stage11.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react'
+import { getStagePath, postStagePath } from '../lib/api'
+
+export default function Stage11() {
+  const [match, setMatch] = useState<any>(null)
+  const [salvageRes, setSalvageRes] = useState<any>(null)
+  const [input, setInput] = useState('')
+
+  const fetchMatch = async () => setMatch(await getStagePath(11, 'match'))
+  const sendSalvage = async () => {
+    setSalvageRes(await postStagePath(11, 'salvage', { item: input }))
+    setInput('')
+  }
+
+  return (
+    <div className="p-2 border rounded mb-2">
+      <h2 className="font-bold">Stage 11</h2>
+      <div className="flex space-x-2 mb-2">
+        <button className="bg-blue-500 text-white px-2 py-1" onClick={fetchMatch}>Get Match</button>
+        <input className="border p-1 flex-1" value={input} onChange={e => setInput(e.target.value)} />
+        <button className="bg-green-500 text-white px-2 py-1" onClick={sendSalvage}>Send Salvage</button>
+      </div>
+      {match && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(match, null, 2)}</pre>}
+      {salvageRes && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(salvageRes, null, 2)}</pre>}
+    </div>
+  )
+}

--- a/frontend/src/components/Stage8.tsx
+++ b/frontend/src/components/Stage8.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react'
+import { getStagePath, postStagePath } from '../lib/api'
+
+export default function Stage8() {
+  const [plan, setPlan] = useState<any>(null)
+  const [telemetryRes, setTelemetryRes] = useState<any>(null)
+  const [input, setInput] = useState('')
+
+  const fetchPlan = async () => setPlan(await getStagePath(8, 'plan'))
+  const sendTelemetry = async () => {
+    setTelemetryRes(await postStagePath(8, 'telemetry', { message: input }))
+    setInput('')
+  }
+
+  return (
+    <div className="p-2 border rounded mb-2">
+      <h2 className="font-bold">Stage 8</h2>
+      <div className="flex space-x-2 mb-2">
+        <button className="bg-blue-500 text-white px-2 py-1" onClick={fetchPlan}>Get Plan</button>
+        <input className="border p-1 flex-1" value={input} onChange={e => setInput(e.target.value)} />
+        <button className="bg-green-500 text-white px-2 py-1" onClick={sendTelemetry}>Send Telemetry</button>
+      </div>
+      {plan && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(plan, null, 2)}</pre>}
+      {telemetryRes && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(telemetryRes, null, 2)}</pre>}
+    </div>
+  )
+}

--- a/frontend/src/components/Stage9.tsx
+++ b/frontend/src/components/Stage9.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react'
+import { getStagePath, postStagePath } from '../lib/api'
+
+export default function Stage9() {
+  const [wellness, setWellness] = useState<any>(null)
+  const [tuningRes, setTuningRes] = useState<any>(null)
+  const [input, setInput] = useState('')
+
+  const fetchWellness = async () => setWellness(await getStagePath(9, 'wellness'))
+  const sendTuning = async () => {
+    setTuningRes(await postStagePath(9, 'tuning', { value: input }))
+    setInput('')
+  }
+
+  return (
+    <div className="p-2 border rounded mb-2">
+      <h2 className="font-bold">Stage 9</h2>
+      <div className="flex space-x-2 mb-2">
+        <button className="bg-blue-500 text-white px-2 py-1" onClick={fetchWellness}>Get Wellness</button>
+        <input className="border p-1 flex-1" value={input} onChange={e => setInput(e.target.value)} />
+        <button className="bg-green-500 text-white px-2 py-1" onClick={sendTuning}>Send Tuning</button>
+      </div>
+      {wellness && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(wellness, null, 2)}</pre>}
+      {tuningRes && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(tuningRes, null, 2)}</pre>}
+    </div>
+  )
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5,3 +5,19 @@ export async function runStage(stage: number) {
   if (!res.ok) throw new Error('request failed')
   return res.json()
 }
+
+export async function getStagePath(stage: number, path: string) {
+  const res = await fetch(`${API_BASE}/stage${stage}/${path}`)
+  if (!res.ok) throw new Error('request failed')
+  return res.json()
+}
+
+export async function postStagePath(stage: number, path: string, data: any) {
+  const res = await fetch(`${API_BASE}/stage${stage}/${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+  if (!res.ok) throw new Error('request failed')
+  return res.json()
+}


### PR DESCRIPTION
## Summary
- implement FastAPI services and routers for stages 8–11 with simple in-memory stores
- extend frontend with panels to view and submit telemetry, tuning, revenue, and salvage data
- document new stages and add tests for all new endpoints

## Testing
- `pytest`
- `docker compose up --build -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68981aabee7c832fa3c41e339b06aed0