### PR TITLE
feat: add task scheduler for stage8

### DIFF
--- a/backend/app/services/stage8.py
+++ b/backend/app/services/stage8.py
@@ -1,8 +1,15 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Callable, Tuple, Optional
+import threading
+import time
+from queue import Queue
 from app.models.stage import StageResult
 
 telemetry_log: List[Dict[str, Any]] = []
 current_plan: Dict[str, Any] = {"tasks": []}
+
+# internal queue for scheduled tasks
+_task_queue: "Queue[Tuple[Callable[[], Any], float]]" = Queue()
+_worker_thread: Optional[threading.Thread] = None
 
 
 def telemetry(data: Dict[str, Any]) -> StageResult:
@@ -14,5 +21,38 @@ def plan() -> StageResult:
     return StageResult(stage=8, status="current plan", data=current_plan)
 
 
-def scheduler_stub() -> None:
-    pass
+def scheduler(task: Callable[[], Any], delay: float = 0.0) -> None:
+    """Schedule a task to be executed after an optional delay.
+
+    Tasks are enqueued and processed by a background worker thread in the
+    order they are received.
+
+    Args:
+        task: Callable with no arguments to execute.
+        delay: Seconds to wait before executing the task.
+    """
+    _task_queue.put((task, delay))
+    _start_worker()
+
+
+def _start_worker() -> None:
+    global _worker_thread
+    if _worker_thread is None or not _worker_thread.is_alive():
+        _worker_thread = threading.Thread(target=_process_queue, daemon=True)
+        _worker_thread.start()
+
+
+def _process_queue() -> None:
+    while not _task_queue.empty():
+        func, delay = _task_queue.get()
+        if delay > 0:
+            time.sleep(delay)
+        func()
+        _task_queue.task_done()
+
+
+def wait_for_all(timeout: Optional[float] = None) -> None:
+    """Block until all scheduled tasks have been processed."""
+    _task_queue.join()
+    if _worker_thread is not None:
+        _worker_thread.join(timeout=timeout)

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import time
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app.services import stage8
+
+
+def test_scheduler_executes_tasks_in_order_and_respects_delay():
+    execution = []
+    start = time.time()
+
+    def task1():
+        execution.append(("t1", time.time()))
+
+    def task2():
+        execution.append(("t2", time.time()))
+
+    stage8.scheduler(task1, delay=0.1)
+    stage8.scheduler(task2)
+    stage8.wait_for_all()
+
+    assert [name for name, _ in execution] == ["t1", "t2"]
+    assert execution[0][1] - start >= 0.1


### PR DESCRIPTION
## Summary
- implement queue-based task scheduler for stage8 service
- add wait helper and threading worker for task execution
- cover scheduler behaviour with unit tests

## Testing
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68981d8a056c832fb71bb8ef1c9b0f03