### PR TITLE
Ensure stage service state isolation

### DIFF
--- a/backend/app/services/stage10.py
+++ b/backend/app/services/stage10.py
@@ -1,14 +1,41 @@
 from typing import Any, Dict, List
+
 from app.models.stage import StageResult
 
-revenue_records: List[Dict[str, Any]] = []
-resilience_metrics: Dict[str, Any] = {"score": 0}
+
+class Stage10Service:
+    """Encapsulates mutable state for Stage 10 operations."""
+
+    def __init__(self) -> None:
+        self.revenue_records: List[Dict[str, Any]] = []
+        self.resilience_metrics: Dict[str, Any] = {"score": 0}
+
+    def revenue(self, data: Dict[str, Any]) -> StageResult:
+        """Record revenue information and return current count."""
+        self.revenue_records.append(data)
+        return StageResult(
+            stage=10,
+            status="revenue recorded",
+            data={"count": len(self.revenue_records)},
+        )
+
+    def resilience(self) -> StageResult:
+        """Return resilience metrics."""
+        return StageResult(stage=10, status="resilience metrics", data=self.resilience_metrics)
+
+
+service = Stage10Service()
 
 
 def revenue(data: Dict[str, Any]) -> StageResult:
-    revenue_records.append(data)
-    return StageResult(stage=10, status="revenue recorded", data={"count": len(revenue_records)})
+    return service.revenue(data)
 
 
 def resilience() -> StageResult:
-    return StageResult(stage=10, status="resilience metrics", data=resilience_metrics)
+    return service.resilience()
+
+
+def reset_state() -> None:
+    """Reset service state for testing purposes."""
+    global service
+    service = Stage10Service()

--- a/backend/app/services/stage11.py
+++ b/backend/app/services/stage11.py
@@ -1,14 +1,41 @@
 from typing import Any, Dict, List
+
 from app.models.stage import StageResult
 
-salvage_reports: List[Dict[str, Any]] = []
-match_state: Dict[str, Any] = {"matches": []}
+
+class Stage11Service:
+    """Encapsulates mutable state for Stage 11 operations."""
+
+    def __init__(self) -> None:
+        self.salvage_reports: List[Dict[str, Any]] = []
+        self.match_state: Dict[str, Any] = {"matches": []}
+
+    def salvage(self, data: Dict[str, Any]) -> StageResult:
+        """Record salvage information and return current count."""
+        self.salvage_reports.append(data)
+        return StageResult(
+            stage=11,
+            status="salvage recorded",
+            data={"count": len(self.salvage_reports)},
+        )
+
+    def match(self) -> StageResult:
+        """Return current match state."""
+        return StageResult(stage=11, status="match info", data=self.match_state)
+
+
+service = Stage11Service()
 
 
 def salvage(data: Dict[str, Any]) -> StageResult:
-    salvage_reports.append(data)
-    return StageResult(stage=11, status="salvage recorded", data={"count": len(salvage_reports)})
+    return service.salvage(data)
 
 
 def match() -> StageResult:
-    return StageResult(stage=11, status="match info", data=match_state)
+    return service.match()
+
+
+def reset_state() -> None:
+    """Reset service state for testing purposes."""
+    global service
+    service = Stage11Service()

--- a/backend/app/services/stage8.py
+++ b/backend/app/services/stage8.py
@@ -1,17 +1,44 @@
 from typing import Any, Dict, List
+
 from app.models.stage import StageResult
 
-telemetry_log: List[Dict[str, Any]] = []
-current_plan: Dict[str, Any] = {"tasks": []}
+
+class Stage8Service:
+    """Encapsulates mutable state for Stage 8 operations."""
+
+    def __init__(self) -> None:
+        self.telemetry_log: List[Dict[str, Any]] = []
+        self.current_plan: Dict[str, Any] = {"tasks": []}
+
+    def telemetry(self, data: Dict[str, Any]) -> StageResult:
+        """Record telemetry data and return count of entries."""
+        self.telemetry_log.append(data)
+        return StageResult(
+            stage=8,
+            status="telemetry received",
+            data={"count": len(self.telemetry_log)},
+        )
+
+    def plan(self) -> StageResult:
+        """Return the current plan state."""
+        return StageResult(stage=8, status="current plan", data=self.current_plan)
+
+
+service = Stage8Service()
 
 
 def telemetry(data: Dict[str, Any]) -> StageResult:
-    telemetry_log.append(data)
-    return StageResult(stage=8, status="telemetry received", data={"count": len(telemetry_log)})
+    return service.telemetry(data)
 
 
 def plan() -> StageResult:
-    return StageResult(stage=8, status="current plan", data=current_plan)
+    return service.plan()
+
+
+def reset_state() -> None:
+    """Reset the service state for testing purposes."""
+    global service
+    service = Stage8Service()
 
 
 def scheduler_stub() -> None:

--- a/backend/app/services/stage9.py
+++ b/backend/app/services/stage9.py
@@ -1,14 +1,41 @@
 from typing import Any, Dict, List
+
 from app.models.stage import StageResult
 
-tuning_events: List[Dict[str, Any]] = []
-wellness_state: Dict[str, Any] = {"status": "nominal"}
+
+class Stage9Service:
+    """Encapsulates mutable state for Stage 9 operations."""
+
+    def __init__(self) -> None:
+        self.tuning_events: List[Dict[str, Any]] = []
+        self.wellness_state: Dict[str, Any] = {"status": "nominal"}
+
+    def tuning(self, data: Dict[str, Any]) -> StageResult:
+        """Record a tuning event and return current count."""
+        self.tuning_events.append(data)
+        return StageResult(
+            stage=9,
+            status="tuning received",
+            data={"count": len(self.tuning_events)},
+        )
+
+    def wellness(self) -> StageResult:
+        """Return current wellness status."""
+        return StageResult(stage=9, status="wellness status", data=self.wellness_state)
+
+
+service = Stage9Service()
 
 
 def tuning(data: Dict[str, Any]) -> StageResult:
-    tuning_events.append(data)
-    return StageResult(stage=9, status="tuning received", data={"count": len(tuning_events)})
+    return service.tuning(data)
 
 
 def wellness() -> StageResult:
-    return StageResult(stage=9, status="wellness status", data=wellness_state)
+    return service.wellness()
+
+
+def reset_state() -> None:
+    """Reset service state for testing purposes."""
+    global service
+    service = Stage9Service()

--- a/backend/tests/test_stages8_11.py
+++ b/backend/tests/test_stages8_11.py
@@ -1,44 +1,84 @@
 import os
 import sys
+
+import pytest
 from fastapi.testclient import TestClient
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from app.main import app
+from app.services import stage8, stage9, stage10, stage11
 
 client = TestClient(app)
 
 
-def test_stage8_endpoints():
+@pytest.fixture(autouse=True)
+def reset_services():
+    """Ensure service state is reset before each test case."""
+    stage8.reset_state()
+    stage9.reset_state()
+    stage10.reset_state()
+    stage11.reset_state()
+
+
+def test_stage8_state_accumulates_within_test():
     res = client.get("/stage8/plan")
     assert res.status_code == 200
     assert res.json()["stage"] == 8
-    res = client.post("/stage8/telemetry", json={"value": 1})
-    assert res.status_code == 200
-    assert res.json()["stage"] == 8
+
+    res1 = client.post("/stage8/telemetry", json={"value": 1})
+    res2 = client.post("/stage8/telemetry", json={"value": 2})
+    assert res1.json()["data"]["count"] == 1
+    assert res2.json()["data"]["count"] == 2
 
 
-def test_stage9_endpoints():
+def test_stage8_state_resets_between_tests():
+    res = client.post("/stage8/telemetry", json={"value": 3})
+    assert res.json()["data"]["count"] == 1
+
+
+def test_stage9_state_accumulates_within_test():
     res = client.get("/stage9/wellness")
     assert res.status_code == 200
     assert res.json()["stage"] == 9
-    res = client.post("/stage9/tuning", json={"value": 1})
-    assert res.status_code == 200
-    assert res.json()["stage"] == 9
+
+    res1 = client.post("/stage9/tuning", json={"value": 1})
+    res2 = client.post("/stage9/tuning", json={"value": 2})
+    assert res1.json()["data"]["count"] == 1
+    assert res2.json()["data"]["count"] == 2
 
 
-def test_stage10_endpoints():
+def test_stage9_state_resets_between_tests():
+    res = client.post("/stage9/tuning", json={"value": 3})
+    assert res.json()["data"]["count"] == 1
+
+
+def test_stage10_state_accumulates_within_test():
     res = client.get("/stage10/resilience")
     assert res.status_code == 200
     assert res.json()["stage"] == 10
-    res = client.post("/stage10/revenue", json={"value": 1})
-    assert res.status_code == 200
-    assert res.json()["stage"] == 10
+
+    res1 = client.post("/stage10/revenue", json={"value": 1})
+    res2 = client.post("/stage10/revenue", json={"value": 2})
+    assert res1.json()["data"]["count"] == 1
+    assert res2.json()["data"]["count"] == 2
 
 
-def test_stage11_endpoints():
+def test_stage10_state_resets_between_tests():
+    res = client.post("/stage10/revenue", json={"value": 3})
+    assert res.json()["data"]["count"] == 1
+
+
+def test_stage11_state_accumulates_within_test():
     res = client.get("/stage11/match")
     assert res.status_code == 200
     assert res.json()["stage"] == 11
-    res = client.post("/stage11/salvage", json={"value": 1})
-    assert res.status_code == 200
-    assert res.json()["stage"] == 11
+
+    res1 = client.post("/stage11/salvage", json={"value": 1})
+    res2 = client.post("/stage11/salvage", json={"value": 2})
+    assert res1.json()["data"]["count"] == 1
+    assert res2.json()["data"]["count"] == 2
+
+
+def test_stage11_state_resets_between_tests():
+    res = client.post("/stage11/salvage", json={"value": 3})
+    assert res.json()["data"]["count"] == 1


### PR DESCRIPTION
## Summary
- Encapsulate mutable state for stages 8–11 in dedicated service classes and add reset helpers
- Reset service instances between tests and verify state isolation
- Expand tests to check state accumulation within a test and reset across tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68981e2d11f4832f898a7ed308895e61