### PR TITLE
Add tests for stage 0-7 endpoints

### DIFF
--- a/backend/tests/test_stages0_7.py
+++ b/backend/tests/test_stages0_7.py
@@ -1,0 +1,56 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_stage0_endpoint():
+    res = client.get("/stage0")
+    assert res.status_code == 200
+    assert res.json()["stage"] == 0
+
+
+def test_stage1_endpoint():
+    res = client.get("/stage1")
+    assert res.status_code == 200
+    assert res.json()["stage"] == 1
+
+
+def test_stage2_endpoint():
+    res = client.get("/stage2")
+    assert res.status_code == 200
+    assert res.json()["stage"] == 2
+
+
+def test_stage3_endpoint():
+    res = client.get("/stage3")
+    assert res.status_code == 200
+    assert res.json()["stage"] == 3
+
+
+def test_stage4_endpoint():
+    res = client.get("/stage4")
+    assert res.status_code == 200
+    assert res.json()["stage"] == 4
+
+
+def test_stage5_endpoint():
+    res = client.get("/stage5")
+    assert res.status_code == 200
+    assert res.json()["stage"] == 5
+
+
+def test_stage6_endpoint():
+    res = client.get("/stage6")
+    assert res.status_code == 200
+    assert res.json()["stage"] == 6
+
+
+def test_stage7_endpoint():
+    res = client.get("/stage7")
+    assert res.status_code == 200
+    assert res.json()["stage"] == 7


### PR DESCRIPTION
## Summary
- add backend tests covering stage0 through stage7 endpoints

## Testing
- `pytest backend/tests/test_stages0_7.py backend/tests/test_stages8_11.py`


------
https://chatgpt.com/codex/tasks/task_e_68981e2e0988832faf210889be79f5d5