### PR TITLE
feat: type Stage8 plan and telemetry responses

### DIFF
--- a/frontend/src/components/Stage8.tsx
+++ b/frontend/src/components/Stage8.tsx
@@ -1,14 +1,34 @@
 import { useState } from 'react'
 import { getStagePath, postStagePath } from '../lib/api'
 
+interface PlanType {
+  stage: number
+  status: string
+  data: {
+    tasks: any[]
+  }
+}
+
+interface TelemetryResponse {
+  stage: number
+  status: string
+  data: {
+    count: number
+  }
+}
+
 export default function Stage8() {
-  const [plan, setPlan] = useState<any>(null)
-  const [telemetryRes, setTelemetryRes] = useState<any>(null)
+  const [plan, setPlan] = useState<PlanType | null>(null)
+  const [telemetryRes, setTelemetryRes] = useState<TelemetryResponse | null>(null)
   const [input, setInput] = useState('')
 
-  const fetchPlan = async () => setPlan(await getStagePath(8, 'plan'))
+  const fetchPlan = async () => {
+    const res = (await getStagePath(8, 'plan')) as PlanType
+    setPlan(res)
+  }
   const sendTelemetry = async () => {
-    setTelemetryRes(await postStagePath(8, 'telemetry', { message: input }))
+    const res = (await postStagePath(8, 'telemetry', { message: input })) as TelemetryResponse
+    setTelemetryRes(res)
     setInput('')
   }
 


### PR DESCRIPTION
## Summary
- define `PlanType` and `TelemetryResponse` interfaces for Stage8 API responses
- use typed `useState` hooks and explicit casting for plan and telemetry data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68981e301f54832f826fc728bce0affb