### PR TITLE
Use BaseSettings for backend configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,12 @@ docker-compose up --build
 ```
 
 The backend will be available at `http://localhost:8000` and the frontend at `http://localhost:5173`.
+
+## Environment Variables
+
+The backend uses `pydantic.BaseSettings` for configuration. Values can be supplied
+via environment variables or a `.env` file in the `backend` directory.
+
+| Variable  | Description                                | Default               |
+|-----------|--------------------------------------------|-----------------------|
+| `APP_NAME` | Title used for the FastAPI application.    | `"God Mode Ultra Flow"` |

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,4 +1,12 @@
-class Settings:
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+
     app_name: str = "God Mode Ultra Flow"
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+
 
 settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,4 +33,4 @@ app.include_router(stage11.router)
 
 @app.get("/")
 async def root():
-    return {"message": "God Mode Ultra Flow API"}
+    return {"message": f"{settings.app_name} API"}


### PR DESCRIPTION
## Summary
- Replace simple Settings class with `pydantic-settings` `BaseSettings` subclass for environment-driven config
- Expose `APP_NAME` with default and load from `.env`
- Use configurable app name in root endpoint and document `APP_NAME` in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68981e31e4a8832fb45f4a15bac826fd