### PR TITLE
Implement combinational variant generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository hosts a full-stack platform implementing the God-Mode Ultra Flow vision. The system orchestrates generative design and construction workflows across twelve stages:
 
 0. Context ingestion
-1. Multi-agent variant generation
+1. Multi-agent variant generation (combinatorial attribute exploration)
 2. Surrogate multiphysics analysis
 3. Multi-objective optimization
 4. Compliance & authority pre-check

--- a/backend/app/ai_agents/negotiator.py
+++ b/backend/app/ai_agents/negotiator.py
@@ -1,10 +1,43 @@
-from typing import List
+from itertools import product
+from typing import Dict, List, Optional
+
 
 class Negotiator:
-    """Simple multi-agent negotiator producing design variants."""
+    """Generate design variants by exploring combinations of attributes.
 
-    def generate_variants(self) -> List[str]:
-        # Placeholder logic
-        return ["variant_a", "variant_b"]
+    The negotiator holds a set of base options representing design attributes
+    (e.g. color, material). ``generate_variants`` combines these attributes using
+    a Cartesian product to produce concrete variant strings.
+    """
+
+    def __init__(self, base_options: Optional[Dict[str, List[str]]] = None) -> None:
+        self.base_options: Dict[str, List[str]] = base_options or {
+            "color": ["red", "blue"],
+            "material": ["steel", "plastic"],
+            "finish": ["matte", "gloss"],
+        }
+
+    def generate_variants(
+        self, options: Optional[Dict[str, List[str]]] = None
+    ) -> List[str]:
+        """Return all variant combinations.
+
+        Args:
+            options: Optional mapping of attribute name to possible values. If not
+                provided, the negotiator's ``base_options`` are used.
+
+        Returns:
+            List[str]: Variant names created by joining attribute choices with
+            underscores. An empty options mapping yields an empty list.
+        """
+
+        opts = options or self.base_options
+        if not opts:
+            return []
+
+        combinations = product(*opts.values())
+        return ["_".join(map(str, combo)) for combo in combinations]
+
 
 negotiator = Negotiator()
+

--- a/backend/app/services/stage1.py
+++ b/backend/app/services/stage1.py
@@ -3,5 +3,6 @@ from app.ai_agents.negotiator import negotiator
 
 
 def run() -> StageResult:
+    """Execute stage 1 by generating combinatorial design variants."""
     variants = negotiator.generate_variants()
     return StageResult(stage=1, status="variants generated", data={"variants": variants})

--- a/backend/tests/test_negotiator.py
+++ b/backend/tests/test_negotiator.py
@@ -1,0 +1,31 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app.ai_agents.negotiator import Negotiator
+
+
+def test_generate_variants_default():
+    negotiator = Negotiator()
+    expected = [
+        "red_steel_matte",
+        "red_steel_gloss",
+        "red_plastic_matte",
+        "red_plastic_gloss",
+        "blue_steel_matte",
+        "blue_steel_gloss",
+        "blue_plastic_matte",
+        "blue_plastic_gloss",
+    ]
+    assert negotiator.generate_variants() == expected
+
+
+def test_generate_variants_custom_options():
+    negotiator = Negotiator()
+    options = {"size": ["S", "L"], "color": ["green"]}
+    assert negotiator.generate_variants(options) == [
+        "S_green",
+        "L_green",
+    ]
+


### PR DESCRIPTION
## Summary
- replace placeholder variant list with Cartesian-product algorithm in `Negotiator`
- document stage 1 variant generation and update README
- add unit tests for `generate_variants`

## Testing
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68981e32e344832f880a52f96746dfa5