### PR TITLE
Remove path hacks from stage 8-11 tests

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,3 +12,8 @@ dependencies = [
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+pythonpath = [
+    "."
+]

--- a/backend/tests/test_stages8_11.py
+++ b/backend/tests/test_stages8_11.py
@@ -1,8 +1,5 @@
-import os
-import sys
 from fastapi.testclient import TestClient
 
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from app.main import app
 
 client = TestClient(app)


### PR DESCRIPTION
## Summary
- load backend package for tests via pytest config instead of sys.path
- remove manual path mutation from stage 8-11 tests

## Testing
- `pytest backend/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_6898215da26c832fb650bd70d1dfcb35