### PR TITLE
refactor: inject per-request services for stages 8-11

### DIFF
--- a/backend/app/routers/stage10.py
+++ b/backend/app/routers/stage10.py
@@ -1,15 +1,18 @@
 from typing import Any, Dict
-from fastapi import APIRouter
-from app.services import stage10
+from fastapi import APIRouter, Depends
+from app.services.stage10 import Stage10Service
 
 router = APIRouter(prefix="/stage10", tags=["Stage 10"])
 
 
 @router.post("/revenue")
-def revenue(payload: Dict[str, Any]):
-    return stage10.revenue(payload)
+def revenue(
+    payload: Dict[str, Any],
+    service: Stage10Service = Depends(Stage10Service),
+):
+    return service.revenue(payload)
 
 
 @router.get("/resilience")
-def resilience():
-    return stage10.resilience()
+def resilience(service: Stage10Service = Depends(Stage10Service)):
+    return service.resilience()

--- a/backend/app/routers/stage11.py
+++ b/backend/app/routers/stage11.py
@@ -1,15 +1,18 @@
 from typing import Any, Dict
-from fastapi import APIRouter
-from app.services import stage11
+from fastapi import APIRouter, Depends
+from app.services.stage11 import Stage11Service
 
 router = APIRouter(prefix="/stage11", tags=["Stage 11"])
 
 
 @router.post("/salvage")
-def salvage(payload: Dict[str, Any]):
-    return stage11.salvage(payload)
+def salvage(
+    payload: Dict[str, Any],
+    service: Stage11Service = Depends(Stage11Service),
+):
+    return service.salvage(payload)
 
 
 @router.get("/match")
-def match():
-    return stage11.match()
+def match(service: Stage11Service = Depends(Stage11Service)):
+    return service.match()

--- a/backend/app/routers/stage8.py
+++ b/backend/app/routers/stage8.py
@@ -1,15 +1,18 @@
 from typing import Any, Dict
-from fastapi import APIRouter
-from app.services import stage8
+from fastapi import APIRouter, Depends
+from app.services.stage8 import Stage8Service
 
 router = APIRouter(prefix="/stage8", tags=["Stage 8"])
 
 
 @router.post("/telemetry")
-def telemetry(payload: Dict[str, Any]):
-    return stage8.telemetry(payload)
+def telemetry(
+    payload: Dict[str, Any],
+    service: Stage8Service = Depends(Stage8Service),
+):
+    return service.telemetry(payload)
 
 
 @router.get("/plan")
-def plan():
-    return stage8.plan()
+def plan(service: Stage8Service = Depends(Stage8Service)):
+    return service.plan()

--- a/backend/app/routers/stage9.py
+++ b/backend/app/routers/stage9.py
@@ -1,15 +1,18 @@
 from typing import Any, Dict
-from fastapi import APIRouter
-from app.services import stage9
+from fastapi import APIRouter, Depends
+from app.services.stage9 import Stage9Service
 
 router = APIRouter(prefix="/stage9", tags=["Stage 9"])
 
 
 @router.post("/tuning")
-def tuning(payload: Dict[str, Any]):
-    return stage9.tuning(payload)
+def tuning(
+    payload: Dict[str, Any],
+    service: Stage9Service = Depends(Stage9Service),
+):
+    return service.tuning(payload)
 
 
 @router.get("/wellness")
-def wellness():
-    return stage9.wellness()
+def wellness(service: Stage9Service = Depends(Stage9Service)):
+    return service.wellness()

--- a/backend/app/services/stage10.py
+++ b/backend/app/services/stage10.py
@@ -1,14 +1,21 @@
 from typing import Any, Dict, List
 from app.models.stage import StageResult
 
-revenue_records: List[Dict[str, Any]] = []
-resilience_metrics: Dict[str, Any] = {"score": 0}
 
+class Stage10Service:
+    def __init__(self) -> None:
+        self.revenue_records: List[Dict[str, Any]] = []
+        self.resilience_metrics: Dict[str, Any] = {"score": 0}
 
-def revenue(data: Dict[str, Any]) -> StageResult:
-    revenue_records.append(data)
-    return StageResult(stage=10, status="revenue recorded", data={"count": len(revenue_records)})
+    def revenue(self, data: Dict[str, Any]) -> StageResult:
+        self.revenue_records.append(data)
+        return StageResult(
+            stage=10,
+            status="revenue recorded",
+            data={"count": len(self.revenue_records)},
+        )
 
-
-def resilience() -> StageResult:
-    return StageResult(stage=10, status="resilience metrics", data=resilience_metrics)
+    def resilience(self) -> StageResult:
+        return StageResult(
+            stage=10, status="resilience metrics", data=self.resilience_metrics
+        )

--- a/backend/app/services/stage11.py
+++ b/backend/app/services/stage11.py
@@ -1,14 +1,19 @@
 from typing import Any, Dict, List
 from app.models.stage import StageResult
 
-salvage_reports: List[Dict[str, Any]] = []
-match_state: Dict[str, Any] = {"matches": []}
 
+class Stage11Service:
+    def __init__(self) -> None:
+        self.salvage_reports: List[Dict[str, Any]] = []
+        self.match_state: Dict[str, Any] = {"matches": []}
 
-def salvage(data: Dict[str, Any]) -> StageResult:
-    salvage_reports.append(data)
-    return StageResult(stage=11, status="salvage recorded", data={"count": len(salvage_reports)})
+    def salvage(self, data: Dict[str, Any]) -> StageResult:
+        self.salvage_reports.append(data)
+        return StageResult(
+            stage=11,
+            status="salvage recorded",
+            data={"count": len(self.salvage_reports)},
+        )
 
-
-def match() -> StageResult:
-    return StageResult(stage=11, status="match info", data=match_state)
+    def match(self) -> StageResult:
+        return StageResult(stage=11, status="match info", data=self.match_state)

--- a/backend/app/services/stage8.py
+++ b/backend/app/services/stage8.py
@@ -4,55 +4,61 @@ import time
 from queue import Queue
 from app.models.stage import StageResult
 
-telemetry_log: List[Dict[str, Any]] = []
-current_plan: Dict[str, Any] = {"tasks": []}
 
-# internal queue for scheduled tasks
-_task_queue: "Queue[Tuple[Callable[[], Any], float]]" = Queue()
-_worker_thread: Optional[threading.Thread] = None
+class Stage8Service:
+    """Service layer for Stage 8 operations.
 
-
-def telemetry(data: Dict[str, Any]) -> StageResult:
-    telemetry_log.append(data)
-    return StageResult(stage=8, status="telemetry received", data={"count": len(telemetry_log)})
-
-
-def plan() -> StageResult:
-    return StageResult(stage=8, status="current plan", data=current_plan)
-
-
-def scheduler(task: Callable[[], Any], delay: float = 0.0) -> None:
-    """Schedule a task to be executed after an optional delay.
-
-    Tasks are enqueued and processed by a background worker thread in the
-    order they are received.
-
-    Args:
-        task: Callable with no arguments to execute.
-        delay: Seconds to wait before executing the task.
+    Each request should create a fresh instance of this service to avoid
+    leaking state between requests or tests.
     """
-    _task_queue.put((task, delay))
-    _start_worker()
 
+    def __init__(self) -> None:
+        self.telemetry_log: List[Dict[str, Any]] = []
+        self.current_plan: Dict[str, Any] = {"tasks": []}
+        self._task_queue: "Queue[Tuple[Callable[[], Any], float]]" = Queue()
+        self._worker_thread: Optional[threading.Thread] = None
 
-def _start_worker() -> None:
-    global _worker_thread
-    if _worker_thread is None or not _worker_thread.is_alive():
-        _worker_thread = threading.Thread(target=_process_queue, daemon=True)
-        _worker_thread.start()
+    def telemetry(self, data: Dict[str, Any]) -> StageResult:
+        self.telemetry_log.append(data)
+        return StageResult(
+            stage=8,
+            status="telemetry received",
+            data={"count": len(self.telemetry_log)},
+        )
 
+    def plan(self) -> StageResult:
+        return StageResult(stage=8, status="current plan", data=self.current_plan)
 
-def _process_queue() -> None:
-    while not _task_queue.empty():
-        func, delay = _task_queue.get()
-        if delay > 0:
-            time.sleep(delay)
-        func()
-        _task_queue.task_done()
+    def scheduler(self, task: Callable[[], Any], delay: float = 0.0) -> None:
+        """Schedule a task to be executed after an optional delay.
 
+        Tasks are enqueued and processed by a background worker thread in the
+        order they are received.
 
-def wait_for_all(timeout: Optional[float] = None) -> None:
-    """Block until all scheduled tasks have been processed."""
-    _task_queue.join()
-    if _worker_thread is not None:
-        _worker_thread.join(timeout=timeout)
+        Args:
+            task: Callable with no arguments to execute.
+            delay: Seconds to wait before executing the task.
+        """
+        self._task_queue.put((task, delay))
+        self._start_worker()
+
+    def _start_worker(self) -> None:
+        if self._worker_thread is None or not self._worker_thread.is_alive():
+            self._worker_thread = threading.Thread(
+                target=self._process_queue, daemon=True
+            )
+            self._worker_thread.start()
+
+    def _process_queue(self) -> None:
+        while not self._task_queue.empty():
+            func, delay = self._task_queue.get()
+            if delay > 0:
+                time.sleep(delay)
+            func()
+            self._task_queue.task_done()
+
+    def wait_for_all(self, timeout: Optional[float] = None) -> None:
+        """Block until all scheduled tasks have been processed."""
+        self._task_queue.join()
+        if self._worker_thread is not None:
+            self._worker_thread.join(timeout=timeout)

--- a/backend/app/services/stage9.py
+++ b/backend/app/services/stage9.py
@@ -1,14 +1,21 @@
 from typing import Any, Dict, List
 from app.models.stage import StageResult
 
-tuning_events: List[Dict[str, Any]] = []
-wellness_state: Dict[str, Any] = {"status": "nominal"}
 
+class Stage9Service:
+    def __init__(self) -> None:
+        self.tuning_events: List[Dict[str, Any]] = []
+        self.wellness_state: Dict[str, Any] = {"status": "nominal"}
 
-def tuning(data: Dict[str, Any]) -> StageResult:
-    tuning_events.append(data)
-    return StageResult(stage=9, status="tuning received", data={"count": len(tuning_events)})
+    def tuning(self, data: Dict[str, Any]) -> StageResult:
+        self.tuning_events.append(data)
+        return StageResult(
+            stage=9,
+            status="tuning received",
+            data={"count": len(self.tuning_events)},
+        )
 
-
-def wellness() -> StageResult:
-    return StageResult(stage=9, status="wellness status", data=wellness_state)
+    def wellness(self) -> StageResult:
+        return StageResult(
+            stage=9, status="wellness status", data=self.wellness_state
+        )

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -2,11 +2,18 @@ import os
 import sys
 import time
 
+import pytest
+
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from app.services import stage8
+from app.services.stage8 import Stage8Service
 
 
-def test_scheduler_executes_tasks_in_order_and_respects_delay():
+@pytest.fixture()
+def stage8_service() -> Stage8Service:
+    return Stage8Service()
+
+
+def test_scheduler_executes_tasks_in_order_and_respects_delay(stage8_service):
     execution = []
     start = time.time()
 
@@ -16,9 +23,9 @@ def test_scheduler_executes_tasks_in_order_and_respects_delay():
     def task2():
         execution.append(("t2", time.time()))
 
-    stage8.scheduler(task1, delay=0.1)
-    stage8.scheduler(task2)
-    stage8.wait_for_all()
+    stage8_service.scheduler(task1, delay=0.1)
+    stage8_service.scheduler(task2)
+    stage8_service.wait_for_all()
 
     assert [name for name, _ in execution] == ["t1", "t2"]
     assert execution[0][1] - start >= 0.1


### PR DESCRIPTION
## Summary
- inject fresh service instances into stage 8–11 routers using FastAPI Depends
- refactor stage 8–11 services into classes without module-level state
- update scheduler test to use service fixture

## Testing
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898215df3f4832f82854406051f3bb0