### PR TITLE
Ensure Negotiator respects explicit options

### DIFF
--- a/backend/app/ai_agents/negotiator.py
+++ b/backend/app/ai_agents/negotiator.py
@@ -31,7 +31,10 @@ class Negotiator:
             underscores. An empty options mapping yields an empty list.
         """
 
-        opts = options or self.base_options
+        # ``None`` indicates that the caller wants to use the negotiator's
+        # ``base_options``. An explicit empty dict should be respected as-is
+        # to allow calls like ``generate_variants({})`` to yield an empty list.
+        opts = self.base_options if options is None else options
         if not opts:
             return []
 

--- a/backend/tests/test_negotiator.py
+++ b/backend/tests/test_negotiator.py
@@ -29,3 +29,8 @@ def test_generate_variants_custom_options():
         "L_green",
     ]
 
+
+def test_generate_variants_empty_options():
+    negotiator = Negotiator()
+    assert negotiator.generate_variants({}) == []
+


### PR DESCRIPTION
## Summary
- avoid falling back to base options when an empty options dict is provided to `generate_variants`
- test that generating variants with an empty options mapping returns an empty list

## Testing
- `pytest tests/test_negotiator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689825129570832f9d01bfc4f09f9a15