### PR TITLE
Add pydantic-settings dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ The backend will be available at `http://localhost:8000` and the frontend at `ht
 
 ## Environment Variables
 
-The backend uses `pydantic.BaseSettings` for configuration. Values can be supplied
-via environment variables or a `.env` file in the `backend` directory.
+The backend uses the `pydantic-settings` package for configuration, built atop
+`pydantic.BaseSettings`. Values can be supplied via environment variables or a
+`.env` file in the `backend` directory.
 
 | Variable  | Description                                | Default               |
 |-----------|--------------------------------------------|-----------------------|

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY pyproject.toml .
-RUN pip install --no-cache-dir fastapi uvicorn[standard] pydantic httpx
+RUN pip install --no-cache-dir fastapi uvicorn[standard] pydantic httpx pydantic-settings>=2.0.0
 COPY app ./app
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,7 +6,8 @@ dependencies = [
     "uvicorn[standard]",
     "pydantic",
     "httpx",
-    "pytest"
+    "pytest",
+    "pydantic-settings>=2.0.0"
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- add `pydantic-settings` to backend dependencies
- install `pydantic-settings` in backend Dockerfile
- document configuration dependency in README

## Testing
- `pip install -e backend`
- `cd backend && pytest`

------
https://chatgpt.com/codex/tasks/task_e_689825149de8832fb7b68032f746f0b7