### PR TITLE
Remove manual sys.path tweaks from tests

### DIFF
--- a/backend/tests/test_negotiator.py
+++ b/backend/tests/test_negotiator.py
@@ -1,8 +1,3 @@
-import os
-import sys
-
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
 from app.ai_agents.negotiator import Negotiator
 
 

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1,10 +1,7 @@
-import os
-import sys
 import time
 
 import pytest
 
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from app.services.stage8 import Stage8Service
 
 

--- a/backend/tests/test_stages0_7.py
+++ b/backend/tests/test_stages0_7.py
@@ -1,8 +1,5 @@
-import os
-import sys
 from fastapi.testclient import TestClient
 
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from app.main import app
 
 client = TestClient(app)


### PR DESCRIPTION
## Summary
- rely on configured pythonpath for imports in tests
- drop redundant sys.path modifications and unused imports

## Testing
- `PYTHONPATH=backend pytest backend/tests/test_negotiator.py backend/tests/test_scheduler.py backend/tests/test_stages0_7.py backend/tests/test_stages8_11.py`

------
https://chatgpt.com/codex/tasks/task_e_689825160a54832fb178f43109014e36