### PR TITLE
Add StageResult response models to stage routers

### DIFF
--- a/backend/app/routers/stage0.py
+++ b/backend/app/routers/stage0.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter
+
+from app.models.stage import StageResult
 from app.services import stage0
 
 router = APIRouter(prefix="/stage0", tags=["Stage 0"])
 
-@router.get("")
+@router.get("", response_model=StageResult)
 def run():
     return stage0.run()

--- a/backend/app/routers/stage1.py
+++ b/backend/app/routers/stage1.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter
+
+from app.models.stage import StageResult
 from app.services import stage1
 
 router = APIRouter(prefix="/stage1", tags=["Stage 1"])
 
-@router.get("")
+@router.get("", response_model=StageResult)
 def run():
     return stage1.run()

--- a/backend/app/routers/stage10.py
+++ b/backend/app/routers/stage10.py
@@ -1,11 +1,14 @@
 from typing import Any, Dict
+
 from fastapi import APIRouter, Depends
+
+from app.models.stage import StageResult
 from app.services.stage10 import Stage10Service
 
 router = APIRouter(prefix="/stage10", tags=["Stage 10"])
 
 
-@router.post("/revenue")
+@router.post("/revenue", response_model=StageResult)
 def revenue(
     payload: Dict[str, Any],
     service: Stage10Service = Depends(Stage10Service),
@@ -13,6 +16,6 @@ def revenue(
     return service.revenue(payload)
 
 
-@router.get("/resilience")
+@router.get("/resilience", response_model=StageResult)
 def resilience(service: Stage10Service = Depends(Stage10Service)):
     return service.resilience()

--- a/backend/app/routers/stage11.py
+++ b/backend/app/routers/stage11.py
@@ -1,11 +1,14 @@
 from typing import Any, Dict
+
 from fastapi import APIRouter, Depends
+
+from app.models.stage import StageResult
 from app.services.stage11 import Stage11Service
 
 router = APIRouter(prefix="/stage11", tags=["Stage 11"])
 
 
-@router.post("/salvage")
+@router.post("/salvage", response_model=StageResult)
 def salvage(
     payload: Dict[str, Any],
     service: Stage11Service = Depends(Stage11Service),
@@ -13,6 +16,6 @@ def salvage(
     return service.salvage(payload)
 
 
-@router.get("/match")
+@router.get("/match", response_model=StageResult)
 def match(service: Stage11Service = Depends(Stage11Service)):
     return service.match()

--- a/backend/app/routers/stage2.py
+++ b/backend/app/routers/stage2.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter
+
+from app.models.stage import StageResult
 from app.services import stage2
 
 router = APIRouter(prefix="/stage2", tags=["Stage 2"])
 
-@router.get("")
+@router.get("", response_model=StageResult)
 def run():
     return stage2.run()

--- a/backend/app/routers/stage3.py
+++ b/backend/app/routers/stage3.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter
+
+from app.models.stage import StageResult
 from app.services import stage3
 
 router = APIRouter(prefix="/stage3", tags=["Stage 3"])
 
-@router.get("")
+@router.get("", response_model=StageResult)
 def run():
     return stage3.run()

--- a/backend/app/routers/stage4.py
+++ b/backend/app/routers/stage4.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter
+
+from app.models.stage import StageResult
 from app.services import stage4
 
 router = APIRouter(prefix="/stage4", tags=["Stage 4"])
 
-@router.get("")
+@router.get("", response_model=StageResult)
 def run():
     return stage4.run()

--- a/backend/app/routers/stage5.py
+++ b/backend/app/routers/stage5.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter
+
+from app.models.stage import StageResult
 from app.services import stage5
 
 router = APIRouter(prefix="/stage5", tags=["Stage 5"])
 
-@router.get("")
+@router.get("", response_model=StageResult)
 def run():
     return stage5.run()

--- a/backend/app/routers/stage6.py
+++ b/backend/app/routers/stage6.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter
+
+from app.models.stage import StageResult
 from app.services import stage6
 
 router = APIRouter(prefix="/stage6", tags=["Stage 6"])
 
-@router.get("")
+@router.get("", response_model=StageResult)
 def run():
     return stage6.run()

--- a/backend/app/routers/stage7.py
+++ b/backend/app/routers/stage7.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter
+
+from app.models.stage import StageResult
 from app.services import stage7
 
 router = APIRouter(prefix="/stage7", tags=["Stage 7"])
 
-@router.get("")
+@router.get("", response_model=StageResult)
 def run():
     return stage7.run()

--- a/backend/app/routers/stage8.py
+++ b/backend/app/routers/stage8.py
@@ -1,11 +1,14 @@
 from typing import Any, Dict
+
 from fastapi import APIRouter, Depends
+
+from app.models.stage import StageResult
 from app.services.stage8 import Stage8Service
 
 router = APIRouter(prefix="/stage8", tags=["Stage 8"])
 
 
-@router.post("/telemetry")
+@router.post("/telemetry", response_model=StageResult)
 def telemetry(
     payload: Dict[str, Any],
     service: Stage8Service = Depends(Stage8Service),
@@ -13,6 +16,6 @@ def telemetry(
     return service.telemetry(payload)
 
 
-@router.get("/plan")
+@router.get("/plan", response_model=StageResult)
 def plan(service: Stage8Service = Depends(Stage8Service)):
     return service.plan()

--- a/backend/app/routers/stage9.py
+++ b/backend/app/routers/stage9.py
@@ -1,11 +1,14 @@
 from typing import Any, Dict
+
 from fastapi import APIRouter, Depends
+
+from app.models.stage import StageResult
 from app.services.stage9 import Stage9Service
 
 router = APIRouter(prefix="/stage9", tags=["Stage 9"])
 
 
-@router.post("/tuning")
+@router.post("/tuning", response_model=StageResult)
 def tuning(
     payload: Dict[str, Any],
     service: Stage9Service = Depends(Stage9Service),
@@ -13,6 +16,6 @@ def tuning(
     return service.tuning(payload)
 
 
-@router.get("/wellness")
+@router.get("/wellness", response_model=StageResult)
 def wellness(service: Stage9Service = Depends(Stage9Service)):
     return service.wellness()


### PR DESCRIPTION
## Summary
- declare `StageResult` as the response model for every stage endpoint
- import `StageResult` in each stage router

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898251b0854832fbaae4f2e852af83c