### PR TITLE
feat: handle API errors consistently

### DIFF
--- a/frontend/src/components/ErrorMessage.tsx
+++ b/frontend/src/components/ErrorMessage.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+interface ErrorMessageProps {
+  message: string | null
+}
+
+export default function ErrorMessage({ message }: ErrorMessageProps) {
+  if (!message) return null
+  return (
+    <div className="mt-2 bg-red-100 text-red-800 p-2 text-sm rounded">
+      {message}
+    </div>
+  )
+}

--- a/frontend/src/components/Stage0.tsx
+++ b/frontend/src/components/Stage0.tsx
@@ -1,13 +1,24 @@
 import { useState } from 'react'
 import { runStage } from '../lib/api'
+import ErrorMessage from './ErrorMessage'
 
 export default function Stage0() {
   const [result, setResult] = useState<any>(null)
-  const handle = async () => setResult(await runStage(0))
+  const [error, setError] = useState<string | null>(null)
+  const handle = async () => {
+    try {
+      setError(null)
+      setResult(await runStage(0))
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
+  }
   return (
     <div className="p-2 border rounded mb-2">
       <h2 className="font-bold">Stage 0</h2>
       <button className="bg-blue-500 text-white px-2 py-1" onClick={handle}>Run</button>
+      <ErrorMessage message={error} />
       {result && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(result,null,2)}</pre>}
     </div>
   )

--- a/frontend/src/components/Stage1.tsx
+++ b/frontend/src/components/Stage1.tsx
@@ -1,13 +1,24 @@
 import { useState } from 'react'
 import { runStage } from '../lib/api'
+import ErrorMessage from './ErrorMessage'
 
 export default function Stage1() {
   const [result, setResult] = useState<any>(null)
-  const handle = async () => setResult(await runStage(1))
+  const [error, setError] = useState<string | null>(null)
+  const handle = async () => {
+    try {
+      setError(null)
+      setResult(await runStage(1))
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
+  }
   return (
     <div className="p-2 border rounded mb-2">
       <h2 className="font-bold">Stage 1</h2>
       <button className="bg-blue-500 text-white px-2 py-1" onClick={handle}>Run</button>
+      <ErrorMessage message={error} />
       {result && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(result,null,2)}</pre>}
     </div>
   )

--- a/frontend/src/components/Stage10.tsx
+++ b/frontend/src/components/Stage10.tsx
@@ -1,15 +1,31 @@
 import { useState } from 'react'
 import { getStagePath, postStagePath } from '../lib/api'
+import ErrorMessage from './ErrorMessage'
 
 export default function Stage10() {
   const [resilience, setResilience] = useState<any>(null)
   const [revenueRes, setRevenueRes] = useState<any>(null)
   const [input, setInput] = useState('')
+  const [error, setError] = useState<string | null>(null)
 
-  const fetchResilience = async () => setResilience(await getStagePath(10, 'resilience'))
+  const fetchResilience = async () => {
+    try {
+      setError(null)
+      setResilience(await getStagePath(10, 'resilience'))
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
+  }
   const sendRevenue = async () => {
-    setRevenueRes(await postStagePath(10, 'revenue', { value: input }))
-    setInput('')
+    try {
+      setError(null)
+      setRevenueRes(await postStagePath(10, 'revenue', { value: input }))
+      setInput('')
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
   }
 
   return (
@@ -20,6 +36,7 @@ export default function Stage10() {
         <input className="border p-1 flex-1" value={input} onChange={e => setInput(e.target.value)} />
         <button className="bg-green-500 text-white px-2 py-1" onClick={sendRevenue}>Send Revenue</button>
       </div>
+      <ErrorMessage message={error} />
       {resilience && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(resilience, null, 2)}</pre>}
       {revenueRes && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(revenueRes, null, 2)}</pre>}
     </div>

--- a/frontend/src/components/Stage11.tsx
+++ b/frontend/src/components/Stage11.tsx
@@ -1,15 +1,31 @@
 import { useState } from 'react'
 import { getStagePath, postStagePath } from '../lib/api'
+import ErrorMessage from './ErrorMessage'
 
 export default function Stage11() {
   const [match, setMatch] = useState<any>(null)
   const [salvageRes, setSalvageRes] = useState<any>(null)
   const [input, setInput] = useState('')
+  const [error, setError] = useState<string | null>(null)
 
-  const fetchMatch = async () => setMatch(await getStagePath(11, 'match'))
+  const fetchMatch = async () => {
+    try {
+      setError(null)
+      setMatch(await getStagePath(11, 'match'))
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
+  }
   const sendSalvage = async () => {
-    setSalvageRes(await postStagePath(11, 'salvage', { item: input }))
-    setInput('')
+    try {
+      setError(null)
+      setSalvageRes(await postStagePath(11, 'salvage', { item: input }))
+      setInput('')
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
   }
 
   return (
@@ -20,6 +36,7 @@ export default function Stage11() {
         <input className="border p-1 flex-1" value={input} onChange={e => setInput(e.target.value)} />
         <button className="bg-green-500 text-white px-2 py-1" onClick={sendSalvage}>Send Salvage</button>
       </div>
+      <ErrorMessage message={error} />
       {match && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(match, null, 2)}</pre>}
       {salvageRes && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(salvageRes, null, 2)}</pre>}
     </div>

--- a/frontend/src/components/Stage2.tsx
+++ b/frontend/src/components/Stage2.tsx
@@ -1,13 +1,24 @@
 import { useState } from 'react'
 import { runStage } from '../lib/api'
+import ErrorMessage from './ErrorMessage'
 
 export default function Stage2() {
   const [result, setResult] = useState<any>(null)
-  const handle = async () => setResult(await runStage(2))
+  const [error, setError] = useState<string | null>(null)
+  const handle = async () => {
+    try {
+      setError(null)
+      setResult(await runStage(2))
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
+  }
   return (
     <div className="p-2 border rounded mb-2">
       <h2 className="font-bold">Stage 2</h2>
       <button className="bg-blue-500 text-white px-2 py-1" onClick={handle}>Run</button>
+      <ErrorMessage message={error} />
       {result && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(result,null,2)}</pre>}
     </div>
   )

--- a/frontend/src/components/Stage3.tsx
+++ b/frontend/src/components/Stage3.tsx
@@ -1,13 +1,24 @@
 import { useState } from 'react'
 import { runStage } from '../lib/api'
+import ErrorMessage from './ErrorMessage'
 
 export default function Stage3() {
   const [result, setResult] = useState<any>(null)
-  const handle = async () => setResult(await runStage(3))
+  const [error, setError] = useState<string | null>(null)
+  const handle = async () => {
+    try {
+      setError(null)
+      setResult(await runStage(3))
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
+  }
   return (
     <div className="p-2 border rounded mb-2">
       <h2 className="font-bold">Stage 3</h2>
       <button className="bg-blue-500 text-white px-2 py-1" onClick={handle}>Run</button>
+      <ErrorMessage message={error} />
       {result && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(result,null,2)}</pre>}
     </div>
   )

--- a/frontend/src/components/Stage4.tsx
+++ b/frontend/src/components/Stage4.tsx
@@ -1,13 +1,24 @@
 import { useState } from 'react'
 import { runStage } from '../lib/api'
+import ErrorMessage from './ErrorMessage'
 
 export default function Stage4() {
   const [result, setResult] = useState<any>(null)
-  const handle = async () => setResult(await runStage(4))
+  const [error, setError] = useState<string | null>(null)
+  const handle = async () => {
+    try {
+      setError(null)
+      setResult(await runStage(4))
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
+  }
   return (
     <div className="p-2 border rounded mb-2">
       <h2 className="font-bold">Stage 4</h2>
       <button className="bg-blue-500 text-white px-2 py-1" onClick={handle}>Run</button>
+      <ErrorMessage message={error} />
       {result && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(result,null,2)}</pre>}
     </div>
   )

--- a/frontend/src/components/Stage5.tsx
+++ b/frontend/src/components/Stage5.tsx
@@ -1,13 +1,24 @@
 import { useState } from 'react'
 import { runStage } from '../lib/api'
+import ErrorMessage from './ErrorMessage'
 
 export default function Stage5() {
   const [result, setResult] = useState<any>(null)
-  const handle = async () => setResult(await runStage(5))
+  const [error, setError] = useState<string | null>(null)
+  const handle = async () => {
+    try {
+      setError(null)
+      setResult(await runStage(5))
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
+  }
   return (
     <div className="p-2 border rounded mb-2">
       <h2 className="font-bold">Stage 5</h2>
       <button className="bg-blue-500 text-white px-2 py-1" onClick={handle}>Run</button>
+      <ErrorMessage message={error} />
       {result && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(result,null,2)}</pre>}
     </div>
   )

--- a/frontend/src/components/Stage6.tsx
+++ b/frontend/src/components/Stage6.tsx
@@ -1,13 +1,24 @@
 import { useState } from 'react'
 import { runStage } from '../lib/api'
+import ErrorMessage from './ErrorMessage'
 
 export default function Stage6() {
   const [result, setResult] = useState<any>(null)
-  const handle = async () => setResult(await runStage(6))
+  const [error, setError] = useState<string | null>(null)
+  const handle = async () => {
+    try {
+      setError(null)
+      setResult(await runStage(6))
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
+  }
   return (
     <div className="p-2 border rounded mb-2">
       <h2 className="font-bold">Stage 6</h2>
       <button className="bg-blue-500 text-white px-2 py-1" onClick={handle}>Run</button>
+      <ErrorMessage message={error} />
       {result && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(result,null,2)}</pre>}
     </div>
   )

--- a/frontend/src/components/Stage7.tsx
+++ b/frontend/src/components/Stage7.tsx
@@ -1,13 +1,24 @@
 import { useState } from 'react'
 import { runStage } from '../lib/api'
+import ErrorMessage from './ErrorMessage'
 
 export default function Stage7() {
   const [result, setResult] = useState<any>(null)
-  const handle = async () => setResult(await runStage(7))
+  const [error, setError] = useState<string | null>(null)
+  const handle = async () => {
+    try {
+      setError(null)
+      setResult(await runStage(7))
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
+  }
   return (
     <div className="p-2 border rounded mb-2">
       <h2 className="font-bold">Stage 7</h2>
       <button className="bg-blue-500 text-white px-2 py-1" onClick={handle}>Run</button>
+      <ErrorMessage message={error} />
       {result && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(result,null,2)}</pre>}
     </div>
   )

--- a/frontend/src/components/Stage8.tsx
+++ b/frontend/src/components/Stage8.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { getStagePath, postStagePath } from '../lib/api'
+import ErrorMessage from './ErrorMessage'
 
 interface PlanType {
   stage: number
@@ -21,15 +22,28 @@ export default function Stage8() {
   const [plan, setPlan] = useState<PlanType | null>(null)
   const [telemetryRes, setTelemetryRes] = useState<TelemetryResponse | null>(null)
   const [input, setInput] = useState('')
+  const [error, setError] = useState<string | null>(null)
 
   const fetchPlan = async () => {
-    const res = (await getStagePath(8, 'plan')) as PlanType
-    setPlan(res)
+    try {
+      setError(null)
+      const res = (await getStagePath(8, 'plan')) as PlanType
+      setPlan(res)
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
   }
   const sendTelemetry = async () => {
-    const res = (await postStagePath(8, 'telemetry', { message: input })) as TelemetryResponse
-    setTelemetryRes(res)
-    setInput('')
+    try {
+      setError(null)
+      const res = (await postStagePath(8, 'telemetry', { message: input })) as TelemetryResponse
+      setTelemetryRes(res)
+      setInput('')
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
   }
 
   return (
@@ -40,6 +54,7 @@ export default function Stage8() {
         <input className="border p-1 flex-1" value={input} onChange={e => setInput(e.target.value)} />
         <button className="bg-green-500 text-white px-2 py-1" onClick={sendTelemetry}>Send Telemetry</button>
       </div>
+      <ErrorMessage message={error} />
       {plan && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(plan, null, 2)}</pre>}
       {telemetryRes && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(telemetryRes, null, 2)}</pre>}
     </div>

--- a/frontend/src/components/Stage9.tsx
+++ b/frontend/src/components/Stage9.tsx
@@ -1,15 +1,31 @@
 import { useState } from 'react'
 import { getStagePath, postStagePath } from '../lib/api'
+import ErrorMessage from './ErrorMessage'
 
 export default function Stage9() {
   const [wellness, setWellness] = useState<any>(null)
   const [tuningRes, setTuningRes] = useState<any>(null)
   const [input, setInput] = useState('')
+  const [error, setError] = useState<string | null>(null)
 
-  const fetchWellness = async () => setWellness(await getStagePath(9, 'wellness'))
+  const fetchWellness = async () => {
+    try {
+      setError(null)
+      setWellness(await getStagePath(9, 'wellness'))
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
+  }
   const sendTuning = async () => {
-    setTuningRes(await postStagePath(9, 'tuning', { value: input }))
-    setInput('')
+    try {
+      setError(null)
+      setTuningRes(await postStagePath(9, 'tuning', { value: input }))
+      setInput('')
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
   }
 
   return (
@@ -20,6 +36,7 @@ export default function Stage9() {
         <input className="border p-1 flex-1" value={input} onChange={e => setInput(e.target.value)} />
         <button className="bg-green-500 text-white px-2 py-1" onClick={sendTuning}>Send Tuning</button>
       </div>
+      <ErrorMessage message={error} />
       {wellness && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(wellness, null, 2)}</pre>}
       {tuningRes && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(tuningRes, null, 2)}</pre>}
     </div>


### PR DESCRIPTION
## Summary
- add reusable `ErrorMessage` component for consistent error UI
- wrap stage API calls in `try/catch` and surface errors to users

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898251df264832f95d9999d2f058f5e