### PR TITLE
docs: document environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,5 @@ The backend uses the `pydantic-settings` package for configuration, built atop
 
 | Variable  | Description                                | Default               |
 |-----------|--------------------------------------------|-----------------------|
-| `APP_NAME` | Title used for the FastAPI application.    | `"God Mode Ultra Flow"` |
+| `APP_NAME` | Title used for the FastAPI backend.    | `"God Mode Ultra Flow"` |
+| `VITE_API_BASE` | Base URL the frontend uses for API requests. | `http://localhost:8000` |


### PR DESCRIPTION
## Summary
- document backend `APP_NAME` variable
- document frontend `VITE_API_BASE` variable

## Testing
- `pytest`
- `npm test` (fails: Missing script `test`)


------
https://chatgpt.com/codex/tasks/task_e_689827aece70832fa7b4ff9910f9a0b4