### PR TITLE
Add docstrings to stage services and routers

### DIFF
--- a/backend/app/routers/stage0.py
+++ b/backend/app/routers/stage0.py
@@ -1,3 +1,5 @@
+"""API router for Stage 0 context ingestion endpoints."""
+
 from fastapi import APIRouter
 
 from app.models.stage import StageResult
@@ -5,6 +7,13 @@ from app.services import stage0
 
 router = APIRouter(prefix="/stage0", tags=["Stage 0"])
 
+
 @router.get("", response_model=StageResult)
-def run():
+def run() -> StageResult:
+    """Ingest initial context for the workflow.
+
+    Returns:
+        StageResult: Outcome of the ingestion step.
+    """
+
     return stage0.run()

--- a/backend/app/routers/stage1.py
+++ b/backend/app/routers/stage1.py
@@ -1,3 +1,5 @@
+"""API router for Stage 1 variant generation endpoints."""
+
 from fastapi import APIRouter
 
 from app.models.stage import StageResult
@@ -5,6 +7,13 @@ from app.services import stage1
 
 router = APIRouter(prefix="/stage1", tags=["Stage 1"])
 
+
 @router.get("", response_model=StageResult)
-def run():
+def run() -> StageResult:
+    """Generate design variants for stage 1.
+
+    Returns:
+        StageResult: Summary of generated variants.
+    """
+
     return stage1.run()

--- a/backend/app/routers/stage10.py
+++ b/backend/app/routers/stage10.py
@@ -1,3 +1,5 @@
+"""API router for Stage 10 revenue and resilience endpoints."""
+
 from typing import Any, Dict
 
 from fastapi import APIRouter, Depends
@@ -12,10 +14,29 @@ router = APIRouter(prefix="/stage10", tags=["Stage 10"])
 def revenue(
     payload: Dict[str, Any],
     service: Stage10Service = Depends(Stage10Service),
-):
+) -> StageResult:
+    """Record revenue information.
+
+    Args:
+        payload: Revenue details to log.
+        service: Stage 10 business logic provider.
+
+    Returns:
+        StageResult: Count of revenue records stored.
+    """
+
     return service.revenue(payload)
 
 
 @router.get("/resilience", response_model=StageResult)
-def resilience(service: Stage10Service = Depends(Stage10Service)):
+def resilience(service: Stage10Service = Depends(Stage10Service)) -> StageResult:
+    """Retrieve resilience metrics.
+
+    Args:
+        service: Stage 10 business logic provider.
+
+    Returns:
+        StageResult: Current resilience metrics.
+    """
+
     return service.resilience()

--- a/backend/app/routers/stage11.py
+++ b/backend/app/routers/stage11.py
@@ -1,3 +1,5 @@
+"""API router for Stage 11 salvage and matching endpoints."""
+
 from typing import Any, Dict
 
 from fastapi import APIRouter, Depends
@@ -12,10 +14,29 @@ router = APIRouter(prefix="/stage11", tags=["Stage 11"])
 def salvage(
     payload: Dict[str, Any],
     service: Stage11Service = Depends(Stage11Service),
-):
+) -> StageResult:
+    """Record a salvage report.
+
+    Args:
+        payload: Details about recovered components.
+        service: Stage 11 business logic provider.
+
+    Returns:
+        StageResult: Count of salvage reports stored.
+    """
+
     return service.salvage(payload)
 
 
 @router.get("/match", response_model=StageResult)
-def match(service: Stage11Service = Depends(Stage11Service)):
+def match(service: Stage11Service = Depends(Stage11Service)) -> StageResult:
+    """Retrieve current matching information.
+
+    Args:
+        service: Stage 11 business logic provider.
+
+    Returns:
+        StageResult: Match data for salvaged parts.
+    """
+
     return service.match()

--- a/backend/app/routers/stage2.py
+++ b/backend/app/routers/stage2.py
@@ -1,3 +1,5 @@
+"""API router for Stage 2 analysis endpoints."""
+
 from fastapi import APIRouter
 
 from app.models.stage import StageResult
@@ -5,6 +7,13 @@ from app.services import stage2
 
 router = APIRouter(prefix="/stage2", tags=["Stage 2"])
 
+
 @router.get("", response_model=StageResult)
-def run():
+def run() -> StageResult:
+    """Execute stage 2 analysis.
+
+    Returns:
+        StageResult: Simulated analysis outcome.
+    """
+
     return stage2.run()

--- a/backend/app/routers/stage3.py
+++ b/backend/app/routers/stage3.py
@@ -1,3 +1,5 @@
+"""API router for Stage 3 optimization endpoints."""
+
 from fastapi import APIRouter
 
 from app.models.stage import StageResult
@@ -5,6 +7,13 @@ from app.services import stage3
 
 router = APIRouter(prefix="/stage3", tags=["Stage 3"])
 
+
 @router.get("", response_model=StageResult)
-def run():
+def run() -> StageResult:
+    """Perform stage 3 optimization.
+
+    Returns:
+        StageResult: Optimization summary.
+    """
+
     return stage3.run()

--- a/backend/app/routers/stage4.py
+++ b/backend/app/routers/stage4.py
@@ -1,3 +1,5 @@
+"""API router for Stage 4 compliance endpoints."""
+
 from fastapi import APIRouter
 
 from app.models.stage import StageResult
@@ -5,6 +7,13 @@ from app.services import stage4
 
 router = APIRouter(prefix="/stage4", tags=["Stage 4"])
 
+
 @router.get("", response_model=StageResult)
-def run():
+def run() -> StageResult:
+    """Run compliance checks for stage 4.
+
+    Returns:
+        StageResult: Compliance evaluation results.
+    """
+
     return stage4.run()

--- a/backend/app/routers/stage5.py
+++ b/backend/app/routers/stage5.py
@@ -1,3 +1,5 @@
+"""API router for Stage 5 procurement endpoints."""
+
 from fastapi import APIRouter
 
 from app.models.stage import StageResult
@@ -5,6 +7,13 @@ from app.services import stage5
 
 router = APIRouter(prefix="/stage5", tags=["Stage 5"])
 
+
 @router.get("", response_model=StageResult)
-def run():
+def run() -> StageResult:
+    """Handle procurement actions for stage 5.
+
+    Returns:
+        StageResult: Procurement summary.
+    """
+
     return stage5.run()

--- a/backend/app/routers/stage6.py
+++ b/backend/app/routers/stage6.py
@@ -1,3 +1,5 @@
+"""API router for Stage 6 fabrication scheduling endpoints."""
+
 from fastapi import APIRouter
 
 from app.models.stage import StageResult
@@ -5,6 +7,13 @@ from app.services import stage6
 
 router = APIRouter(prefix="/stage6", tags=["Stage 6"])
 
+
 @router.get("", response_model=StageResult)
-def run():
+def run() -> StageResult:
+    """Schedule fabrication for stage 6.
+
+    Returns:
+        StageResult: Fabrication plan details.
+    """
+
     return stage6.run()

--- a/backend/app/routers/stage7.py
+++ b/backend/app/routers/stage7.py
@@ -1,3 +1,5 @@
+"""API router for Stage 7 permitting endpoints."""
+
 from fastapi import APIRouter
 
 from app.models.stage import StageResult
@@ -5,6 +7,13 @@ from app.services import stage7
 
 router = APIRouter(prefix="/stage7", tags=["Stage 7"])
 
+
 @router.get("", response_model=StageResult)
-def run():
+def run() -> StageResult:
+    """Submit permitting information for stage 7.
+
+    Returns:
+        StageResult: Permit status information.
+    """
+
     return stage7.run()

--- a/backend/app/routers/stage8.py
+++ b/backend/app/routers/stage8.py
@@ -1,3 +1,5 @@
+"""API router for Stage 8 telemetry and planning endpoints."""
+
 from typing import Any, Dict
 
 from fastapi import APIRouter, Depends
@@ -12,10 +14,32 @@ router = APIRouter(prefix="/stage8", tags=["Stage 8"])
 def telemetry(
     payload: Dict[str, Any],
     service: Stage8Service = Depends(Stage8Service),
-):
+) -> StageResult:
+    """Record telemetry information.
+
+    Args:
+        payload: Sensor readings or status updates.
+        service: Stage 8 business logic provider.
+
+    Returns:
+        StageResult: Count of telemetry entries stored.
+
+    Example:
+        >>> client.post("/stage8/telemetry", json={"temp": 70})
+    """
+
     return service.telemetry(payload)
 
 
 @router.get("/plan", response_model=StageResult)
-def plan(service: Stage8Service = Depends(Stage8Service)):
+def plan(service: Stage8Service = Depends(Stage8Service)) -> StageResult:
+    """Retrieve the current execution plan.
+
+    Args:
+        service: Stage 8 business logic provider.
+
+    Returns:
+        StageResult: Scheduled tasks for Stage 8.
+    """
+
     return service.plan()

--- a/backend/app/routers/stage9.py
+++ b/backend/app/routers/stage9.py
@@ -1,3 +1,5 @@
+"""API router for Stage 9 tuning and wellness endpoints."""
+
 from typing import Any, Dict
 
 from fastapi import APIRouter, Depends
@@ -12,10 +14,32 @@ router = APIRouter(prefix="/stage9", tags=["Stage 9"])
 def tuning(
     payload: Dict[str, Any],
     service: Stage9Service = Depends(Stage9Service),
-):
+) -> StageResult:
+    """Record a tuning event.
+
+    Args:
+        payload: Parameters adjusted during tuning.
+        service: Stage 9 business logic provider.
+
+    Returns:
+        StageResult: Count of tuning events recorded.
+
+    Example:
+        >>> client.post("/stage9/tuning", json={"gain": 1.2})
+    """
+
     return service.tuning(payload)
 
 
 @router.get("/wellness", response_model=StageResult)
-def wellness(service: Stage9Service = Depends(Stage9Service)):
+def wellness(service: Stage9Service = Depends(Stage9Service)) -> StageResult:
+    """Retrieve system wellness information.
+
+    Args:
+        service: Stage 9 business logic provider.
+
+    Returns:
+        StageResult: Current wellness summary.
+    """
+
     return service.wellness()

--- a/backend/app/services/stage0.py
+++ b/backend/app/services/stage0.py
@@ -1,6 +1,14 @@
+"""Service functions for Stage 0 context ingestion."""
+
 from app.models.stage import StageResult
 
 
 def run() -> StageResult:
+    """Ingest initial context for the workflow.
+
+    Returns:
+        StageResult: Outcome of the ingestion step with a status message.
+    """
+
     data = {"message": "context ingested"}
     return StageResult(stage=0, status="context ingested", data=data)

--- a/backend/app/services/stage1.py
+++ b/backend/app/services/stage1.py
@@ -1,8 +1,15 @@
+"""Service functions for Stage 1 variant generation."""
+
 from app.models.stage import StageResult
 from app.ai_agents.negotiator import negotiator
 
 
 def run() -> StageResult:
-    """Execute stage 1 by generating combinatorial design variants."""
+    """Generate combinatorial design variants.
+
+    Returns:
+        StageResult: Details about the produced design variants.
+    """
+
     variants = negotiator.generate_variants()
     return StageResult(stage=1, status="variants generated", data={"variants": variants})

--- a/backend/app/services/stage10.py
+++ b/backend/app/services/stage10.py
@@ -1,13 +1,26 @@
+"""Financial tracking and resilience metrics for Stage 10."""
+
 from typing import Any, Dict, List
 from app.models.stage import StageResult
 
 
 class Stage10Service:
+    """Record revenue and expose resilience metrics for Stage 10."""
+
     def __init__(self) -> None:
         self.revenue_records: List[Dict[str, Any]] = []
         self.resilience_metrics: Dict[str, Any] = {"score": 0}
 
     def revenue(self, data: Dict[str, Any]) -> StageResult:
+        """Store revenue information.
+
+        Args:
+            data: Revenue details to record.
+
+        Returns:
+            StageResult: Count of revenue records stored.
+        """
+
         self.revenue_records.append(data)
         return StageResult(
             stage=10,
@@ -16,6 +29,12 @@ class Stage10Service:
         )
 
     def resilience(self) -> StageResult:
+        """Provide resilience metrics.
+
+        Returns:
+            StageResult: Current resilience score.
+        """
+
         return StageResult(
             stage=10, status="resilience metrics", data=self.resilience_metrics
         )

--- a/backend/app/services/stage11.py
+++ b/backend/app/services/stage11.py
@@ -1,13 +1,26 @@
+"""Salvage reporting and matching utilities for Stage 11."""
+
 from typing import Any, Dict, List
 from app.models.stage import StageResult
 
 
 class Stage11Service:
+    """Handle salvage reports and part matching for Stage 11."""
+
     def __init__(self) -> None:
         self.salvage_reports: List[Dict[str, Any]] = []
         self.match_state: Dict[str, Any] = {"matches": []}
 
     def salvage(self, data: Dict[str, Any]) -> StageResult:
+        """Record salvage information.
+
+        Args:
+            data: Details about recovered components.
+
+        Returns:
+            StageResult: Count of salvage reports recorded.
+        """
+
         self.salvage_reports.append(data)
         return StageResult(
             stage=11,
@@ -16,4 +29,10 @@ class Stage11Service:
         )
 
     def match(self) -> StageResult:
+        """Retrieve current matching state.
+
+        Returns:
+            StageResult: Information about available matches.
+        """
+
         return StageResult(stage=11, status="match info", data=self.match_state)

--- a/backend/app/services/stage2.py
+++ b/backend/app/services/stage2.py
@@ -1,5 +1,13 @@
+"""Service functions for Stage 2 analysis simulation."""
+
 from app.models.stage import StageResult
 
 
 def run() -> StageResult:
+    """Simulate analysis for stage 2.
+
+    Returns:
+        StageResult: Simulated analysis outcome.
+    """
+
     return StageResult(stage=2, status="analysis complete", data={"result": "simulated"})

--- a/backend/app/services/stage3.py
+++ b/backend/app/services/stage3.py
@@ -1,5 +1,13 @@
+"""Service functions for Stage 3 optimization."""
+
 from app.models.stage import StageResult
 
 
 def run() -> StageResult:
+    """Perform optimization for stage 3.
+
+    Returns:
+        StageResult: Optimization summary including best score.
+    """
+
     return StageResult(stage=3, status="optimization complete", data={"best_score": 0.9})

--- a/backend/app/services/stage4.py
+++ b/backend/app/services/stage4.py
@@ -1,5 +1,13 @@
+"""Service functions for Stage 4 compliance checks."""
+
 from app.models.stage import StageResult
 
 
 def run() -> StageResult:
+    """Perform compliance evaluation for stage 4.
+
+    Returns:
+        StageResult: Outcome of compliance checks including any issues.
+    """
+
     return StageResult(stage=4, status="compliance check passed", data={"issues": []})

--- a/backend/app/services/stage5.py
+++ b/backend/app/services/stage5.py
@@ -1,5 +1,13 @@
+"""Service functions for Stage 5 procurement."""
+
 from app.models.stage import StageResult
 
 
 def run() -> StageResult:
+    """Handle procurement tasks for stage 5.
+
+    Returns:
+        StageResult: Procurement results such as acquired contracts.
+    """
+
     return StageResult(stage=5, status="procurement complete", data={"contracts": []})

--- a/backend/app/services/stage6.py
+++ b/backend/app/services/stage6.py
@@ -1,5 +1,13 @@
+"""Service functions for Stage 6 fabrication scheduling."""
+
 from app.models.stage import StageResult
 
 
 def run() -> StageResult:
+    """Schedule fabrication for stage 6.
+
+    Returns:
+        StageResult: Details about the fabrication plan.
+    """
+
     return StageResult(stage=6, status="fabrication scheduled", data={"robots": 3})

--- a/backend/app/services/stage7.py
+++ b/backend/app/services/stage7.py
@@ -1,5 +1,13 @@
+"""Service functions for Stage 7 permitting."""
+
 from app.models.stage import StageResult
 
 
 def run() -> StageResult:
+    """Submit permitting information for stage 7.
+
+    Returns:
+        StageResult: Current permit status.
+    """
+
     return StageResult(stage=7, status="permit submitted", data={"approved": False})

--- a/backend/app/services/stage8.py
+++ b/backend/app/services/stage8.py
@@ -1,3 +1,5 @@
+"""Telemetry collection and scheduling utilities for Stage 8."""
+
 from typing import Any, Dict, List, Callable, Tuple, Optional
 import threading
 import time
@@ -19,6 +21,15 @@ class Stage8Service:
         self._worker_thread: Optional[threading.Thread] = None
 
     def telemetry(self, data: Dict[str, Any]) -> StageResult:
+        """Record incoming telemetry data.
+
+        Args:
+            data: Arbitrary sensor readings or status information.
+
+        Returns:
+            StageResult: Count of telemetry records stored.
+        """
+
         self.telemetry_log.append(data)
         return StageResult(
             stage=8,
@@ -27,6 +38,12 @@ class Stage8Service:
         )
 
     def plan(self) -> StageResult:
+        """Return the current execution plan.
+
+        Returns:
+            StageResult: Tasks scheduled for Stage 8 operations.
+        """
+
         return StageResult(stage=8, status="current plan", data=self.current_plan)
 
     def scheduler(self, task: Callable[[], Any], delay: float = 0.0) -> None:

--- a/backend/app/services/stage9.py
+++ b/backend/app/services/stage9.py
@@ -1,13 +1,26 @@
+"""Monitoring and tuning utilities for Stage 9."""
+
 from typing import Any, Dict, List
 from app.models.stage import StageResult
 
 
 class Stage9Service:
+    """Manage tuning events and wellness state for Stage 9."""
+
     def __init__(self) -> None:
         self.tuning_events: List[Dict[str, Any]] = []
         self.wellness_state: Dict[str, Any] = {"status": "nominal"}
 
     def tuning(self, data: Dict[str, Any]) -> StageResult:
+        """Record a tuning event.
+
+        Args:
+            data: Parameters that were adjusted during tuning.
+
+        Returns:
+            StageResult: Count of tuning events recorded.
+        """
+
         self.tuning_events.append(data)
         return StageResult(
             stage=9,
@@ -16,6 +29,12 @@ class Stage9Service:
         )
 
     def wellness(self) -> StageResult:
+        """Retrieve current wellness status.
+
+        Returns:
+            StageResult: Summary of system wellness.
+        """
+
         return StageResult(
             stage=9, status="wellness status", data=self.wellness_state
         )


### PR DESCRIPTION
## Summary
- document all stage service and router modules
- include usage examples for Stage 8 telemetry and Stage 9 tuning endpoints
- verify FastAPI docs expose the new descriptions

## Testing
- `pytest`
- `python - <<'PY'
from fastapi.testclient import TestClient
from app.main import app
client = TestClient(app)
openapi = client.get('/openapi.json').json()
print('Stage8 telemetry description:', openapi['paths']['/stage8/telemetry']['post']['description'])
print('Stage9 tuning description:', openapi['paths']['/stage9/tuning']['post']['description'])
PY`


------
https://chatgpt.com/codex/tasks/task_e_689827af8e5c832faf0202026c5c2e0e