### PR TITLE
feat: add stage runner component and shared result types

### DIFF
--- a/frontend/src/components/Stage0.tsx
+++ b/frontend/src/components/Stage0.tsx
@@ -1,25 +1,5 @@
-import { useState } from 'react'
-import { runStage } from '../lib/api'
-import ErrorMessage from './ErrorMessage'
+import StageRunner from './StageRunner'
 
 export default function Stage0() {
-  const [result, setResult] = useState<any>(null)
-  const [error, setError] = useState<string | null>(null)
-  const handle = async () => {
-    try {
-      setError(null)
-      setResult(await runStage(0))
-    } catch (e) {
-      const message = e instanceof Error ? e.message : 'Unknown error'
-      setError(message)
-    }
-  }
-  return (
-    <div className="p-2 border rounded mb-2">
-      <h2 className="font-bold">Stage 0</h2>
-      <button className="bg-blue-500 text-white px-2 py-1" onClick={handle}>Run</button>
-      <ErrorMessage message={error} />
-      {result && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(result,null,2)}</pre>}
-    </div>
-  )
+  return <StageRunner stage={0} />
 }

--- a/frontend/src/components/Stage1.tsx
+++ b/frontend/src/components/Stage1.tsx
@@ -1,25 +1,5 @@
-import { useState } from 'react'
-import { runStage } from '../lib/api'
-import ErrorMessage from './ErrorMessage'
+import StageRunner from './StageRunner'
 
 export default function Stage1() {
-  const [result, setResult] = useState<any>(null)
-  const [error, setError] = useState<string | null>(null)
-  const handle = async () => {
-    try {
-      setError(null)
-      setResult(await runStage(1))
-    } catch (e) {
-      const message = e instanceof Error ? e.message : 'Unknown error'
-      setError(message)
-    }
-  }
-  return (
-    <div className="p-2 border rounded mb-2">
-      <h2 className="font-bold">Stage 1</h2>
-      <button className="bg-blue-500 text-white px-2 py-1" onClick={handle}>Run</button>
-      <ErrorMessage message={error} />
-      {result && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(result,null,2)}</pre>}
-    </div>
-  )
+  return <StageRunner stage={1} />
 }

--- a/frontend/src/components/Stage10.tsx
+++ b/frontend/src/components/Stage10.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react'
 import { getStagePath, postStagePath } from '../lib/api'
+import type { StageResult } from '../lib/StageResult'
 import ErrorMessage from './ErrorMessage'
 
 export default function Stage10() {
-  const [resilience, setResilience] = useState<any>(null)
-  const [revenueRes, setRevenueRes] = useState<any>(null)
+  const [resilience, setResilience] = useState<StageResult | null>(null)
+  const [revenueRes, setRevenueRes] = useState<StageResult | null>(null)
   const [input, setInput] = useState('')
   const [error, setError] = useState<string | null>(null)
 

--- a/frontend/src/components/Stage11.tsx
+++ b/frontend/src/components/Stage11.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react'
 import { getStagePath, postStagePath } from '../lib/api'
+import type { StageResult } from '../lib/StageResult'
 import ErrorMessage from './ErrorMessage'
 
 export default function Stage11() {
-  const [match, setMatch] = useState<any>(null)
-  const [salvageRes, setSalvageRes] = useState<any>(null)
+  const [match, setMatch] = useState<StageResult | null>(null)
+  const [salvageRes, setSalvageRes] = useState<StageResult | null>(null)
   const [input, setInput] = useState('')
   const [error, setError] = useState<string | null>(null)
 

--- a/frontend/src/components/Stage2.tsx
+++ b/frontend/src/components/Stage2.tsx
@@ -1,25 +1,5 @@
-import { useState } from 'react'
-import { runStage } from '../lib/api'
-import ErrorMessage from './ErrorMessage'
+import StageRunner from './StageRunner'
 
 export default function Stage2() {
-  const [result, setResult] = useState<any>(null)
-  const [error, setError] = useState<string | null>(null)
-  const handle = async () => {
-    try {
-      setError(null)
-      setResult(await runStage(2))
-    } catch (e) {
-      const message = e instanceof Error ? e.message : 'Unknown error'
-      setError(message)
-    }
-  }
-  return (
-    <div className="p-2 border rounded mb-2">
-      <h2 className="font-bold">Stage 2</h2>
-      <button className="bg-blue-500 text-white px-2 py-1" onClick={handle}>Run</button>
-      <ErrorMessage message={error} />
-      {result && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(result,null,2)}</pre>}
-    </div>
-  )
+  return <StageRunner stage={2} />
 }

--- a/frontend/src/components/Stage3.tsx
+++ b/frontend/src/components/Stage3.tsx
@@ -1,25 +1,5 @@
-import { useState } from 'react'
-import { runStage } from '../lib/api'
-import ErrorMessage from './ErrorMessage'
+import StageRunner from './StageRunner'
 
 export default function Stage3() {
-  const [result, setResult] = useState<any>(null)
-  const [error, setError] = useState<string | null>(null)
-  const handle = async () => {
-    try {
-      setError(null)
-      setResult(await runStage(3))
-    } catch (e) {
-      const message = e instanceof Error ? e.message : 'Unknown error'
-      setError(message)
-    }
-  }
-  return (
-    <div className="p-2 border rounded mb-2">
-      <h2 className="font-bold">Stage 3</h2>
-      <button className="bg-blue-500 text-white px-2 py-1" onClick={handle}>Run</button>
-      <ErrorMessage message={error} />
-      {result && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(result,null,2)}</pre>}
-    </div>
-  )
+  return <StageRunner stage={3} />
 }

--- a/frontend/src/components/Stage4.tsx
+++ b/frontend/src/components/Stage4.tsx
@@ -1,25 +1,5 @@
-import { useState } from 'react'
-import { runStage } from '../lib/api'
-import ErrorMessage from './ErrorMessage'
+import StageRunner from './StageRunner'
 
 export default function Stage4() {
-  const [result, setResult] = useState<any>(null)
-  const [error, setError] = useState<string | null>(null)
-  const handle = async () => {
-    try {
-      setError(null)
-      setResult(await runStage(4))
-    } catch (e) {
-      const message = e instanceof Error ? e.message : 'Unknown error'
-      setError(message)
-    }
-  }
-  return (
-    <div className="p-2 border rounded mb-2">
-      <h2 className="font-bold">Stage 4</h2>
-      <button className="bg-blue-500 text-white px-2 py-1" onClick={handle}>Run</button>
-      <ErrorMessage message={error} />
-      {result && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(result,null,2)}</pre>}
-    </div>
-  )
+  return <StageRunner stage={4} />
 }

--- a/frontend/src/components/Stage5.tsx
+++ b/frontend/src/components/Stage5.tsx
@@ -1,25 +1,5 @@
-import { useState } from 'react'
-import { runStage } from '../lib/api'
-import ErrorMessage from './ErrorMessage'
+import StageRunner from './StageRunner'
 
 export default function Stage5() {
-  const [result, setResult] = useState<any>(null)
-  const [error, setError] = useState<string | null>(null)
-  const handle = async () => {
-    try {
-      setError(null)
-      setResult(await runStage(5))
-    } catch (e) {
-      const message = e instanceof Error ? e.message : 'Unknown error'
-      setError(message)
-    }
-  }
-  return (
-    <div className="p-2 border rounded mb-2">
-      <h2 className="font-bold">Stage 5</h2>
-      <button className="bg-blue-500 text-white px-2 py-1" onClick={handle}>Run</button>
-      <ErrorMessage message={error} />
-      {result && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(result,null,2)}</pre>}
-    </div>
-  )
+  return <StageRunner stage={5} />
 }

--- a/frontend/src/components/Stage6.tsx
+++ b/frontend/src/components/Stage6.tsx
@@ -1,25 +1,5 @@
-import { useState } from 'react'
-import { runStage } from '../lib/api'
-import ErrorMessage from './ErrorMessage'
+import StageRunner from './StageRunner'
 
 export default function Stage6() {
-  const [result, setResult] = useState<any>(null)
-  const [error, setError] = useState<string | null>(null)
-  const handle = async () => {
-    try {
-      setError(null)
-      setResult(await runStage(6))
-    } catch (e) {
-      const message = e instanceof Error ? e.message : 'Unknown error'
-      setError(message)
-    }
-  }
-  return (
-    <div className="p-2 border rounded mb-2">
-      <h2 className="font-bold">Stage 6</h2>
-      <button className="bg-blue-500 text-white px-2 py-1" onClick={handle}>Run</button>
-      <ErrorMessage message={error} />
-      {result && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(result,null,2)}</pre>}
-    </div>
-  )
+  return <StageRunner stage={6} />
 }

--- a/frontend/src/components/Stage7.tsx
+++ b/frontend/src/components/Stage7.tsx
@@ -1,25 +1,5 @@
-import { useState } from 'react'
-import { runStage } from '../lib/api'
-import ErrorMessage from './ErrorMessage'
+import StageRunner from './StageRunner'
 
 export default function Stage7() {
-  const [result, setResult] = useState<any>(null)
-  const [error, setError] = useState<string | null>(null)
-  const handle = async () => {
-    try {
-      setError(null)
-      setResult(await runStage(7))
-    } catch (e) {
-      const message = e instanceof Error ? e.message : 'Unknown error'
-      setError(message)
-    }
-  }
-  return (
-    <div className="p-2 border rounded mb-2">
-      <h2 className="font-bold">Stage 7</h2>
-      <button className="bg-blue-500 text-white px-2 py-1" onClick={handle}>Run</button>
-      <ErrorMessage message={error} />
-      {result && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(result,null,2)}</pre>}
-    </div>
-  )
+  return <StageRunner stage={7} />
 }

--- a/frontend/src/components/Stage8.tsx
+++ b/frontend/src/components/Stage8.tsx
@@ -1,33 +1,18 @@
 import { useState } from 'react'
 import { getStagePath, postStagePath } from '../lib/api'
+import type { StageResult } from '../lib/StageResult'
 import ErrorMessage from './ErrorMessage'
 
-interface PlanType {
-  stage: number
-  status: string
-  data: {
-    tasks: any[]
-  }
-}
-
-interface TelemetryResponse {
-  stage: number
-  status: string
-  data: {
-    count: number
-  }
-}
-
 export default function Stage8() {
-  const [plan, setPlan] = useState<PlanType | null>(null)
-  const [telemetryRes, setTelemetryRes] = useState<TelemetryResponse | null>(null)
+  const [plan, setPlan] = useState<StageResult | null>(null)
+  const [telemetryRes, setTelemetryRes] = useState<StageResult | null>(null)
   const [input, setInput] = useState('')
   const [error, setError] = useState<string | null>(null)
 
   const fetchPlan = async () => {
     try {
       setError(null)
-      const res = (await getStagePath(8, 'plan')) as PlanType
+      const res = await getStagePath(8, 'plan')
       setPlan(res)
     } catch (e) {
       const message = e instanceof Error ? e.message : 'Unknown error'
@@ -37,7 +22,7 @@ export default function Stage8() {
   const sendTelemetry = async () => {
     try {
       setError(null)
-      const res = (await postStagePath(8, 'telemetry', { message: input })) as TelemetryResponse
+      const res = await postStagePath(8, 'telemetry', { message: input })
       setTelemetryRes(res)
       setInput('')
     } catch (e) {

--- a/frontend/src/components/Stage9.tsx
+++ b/frontend/src/components/Stage9.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react'
 import { getStagePath, postStagePath } from '../lib/api'
+import type { StageResult } from '../lib/StageResult'
 import ErrorMessage from './ErrorMessage'
 
 export default function Stage9() {
-  const [wellness, setWellness] = useState<any>(null)
-  const [tuningRes, setTuningRes] = useState<any>(null)
+  const [wellness, setWellness] = useState<StageResult | null>(null)
+  const [tuningRes, setTuningRes] = useState<StageResult | null>(null)
   const [input, setInput] = useState('')
   const [error, setError] = useState<string | null>(null)
 

--- a/frontend/src/components/StageRunner.tsx
+++ b/frontend/src/components/StageRunner.tsx
@@ -1,0 +1,42 @@
+import { useState, type ReactNode } from 'react'
+import { runStage } from '../lib/api'
+import type { StageResult } from '../lib/StageResult'
+import ErrorMessage from './ErrorMessage'
+
+interface StageRunnerProps {
+  stage: number
+  children?: ReactNode
+}
+
+export default function StageRunner({ stage, children }: StageRunnerProps) {
+  const [result, setResult] = useState<StageResult | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const handle = async () => {
+    try {
+      setError(null)
+      setResult(await runStage(stage))
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
+  }
+
+  return (
+    <div className="p-2 border rounded mb-2">
+      <h2 className="font-bold">Stage {stage}</h2>
+      <div className="mb-2">
+        <button className="bg-blue-500 text-white px-2 py-1" onClick={handle}>
+          Run
+        </button>
+        {children}
+      </div>
+      <ErrorMessage message={error} />
+      {result && (
+        <pre className="mt-2 bg-gray-100 p-2 text-sm">
+          {JSON.stringify(result, null, 2)}
+        </pre>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/lib/StageResult.ts
+++ b/frontend/src/lib/StageResult.ts
@@ -1,0 +1,5 @@
+export interface StageResult {
+  stage: number;
+  status: string;
+  data?: unknown;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,18 +1,24 @@
+import type { StageResult } from './StageResult'
+
 const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8000'
 
-export async function runStage(stage: number) {
+export async function runStage(stage: number): Promise<StageResult> {
   const res = await fetch(`${API_BASE}/stage${stage}`)
   if (!res.ok) throw new Error('request failed')
   return res.json()
 }
 
-export async function getStagePath(stage: number, path: string) {
+export async function getStagePath(stage: number, path: string): Promise<StageResult> {
   const res = await fetch(`${API_BASE}/stage${stage}/${path}`)
   if (!res.ok) throw new Error('request failed')
   return res.json()
 }
 
-export async function postStagePath(stage: number, path: string, data: any) {
+export async function postStagePath(
+  stage: number,
+  path: string,
+  data: unknown
+): Promise<StageResult> {
   const res = await fetch(`${API_BASE}/stage${stage}/${path}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- add StageResult interface and typed API helpers
- introduce reusable StageRunner component
- refactor stage components to use StageRunner and StageResult

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689827af8ecc832fba61d07a1a254c44