### PR TITLE
Add loading indicators for Stage8 network actions

### DIFF
--- a/frontend/src/components/Stage8.tsx
+++ b/frontend/src/components/Stage8.tsx
@@ -8,26 +8,39 @@ export default function Stage8() {
   const [telemetryRes, setTelemetryRes] = useState<StageResult | null>(null)
   const [input, setInput] = useState('')
   const [error, setError] = useState<string | null>(null)
+  const [isFetchingPlan, setIsFetchingPlan] = useState(false)
+  const [isSendingTelemetry, setIsSendingTelemetry] = useState(false)
 
-  const fetchPlan = async () => {
+  const withLoading = async <T>(
+    action: () => Promise<T>,
+    setLoading: (flag: boolean) => void
+  ) => {
     try {
       setError(null)
-      const res = await getStagePath(8, 'plan')
-      setPlan(res)
+      setLoading(true)
+      return await action()
     } catch (e) {
       const message = e instanceof Error ? e.message : 'Unknown error'
       setError(message)
+      return null
+    } finally {
+      setLoading(false)
     }
   }
+
+  const fetchPlan = async () => {
+    const res = await withLoading(() => getStagePath(8, 'plan'), setIsFetchingPlan)
+    if (res) setPlan(res)
+  }
+
   const sendTelemetry = async () => {
-    try {
-      setError(null)
-      const res = await postStagePath(8, 'telemetry', { message: input })
+    const res = await withLoading(
+      () => postStagePath(8, 'telemetry', { message: input }),
+      setIsSendingTelemetry
+    )
+    if (res) {
       setTelemetryRes(res)
       setInput('')
-    } catch (e) {
-      const message = e instanceof Error ? e.message : 'Unknown error'
-      setError(message)
     }
   }
 
@@ -35,9 +48,25 @@ export default function Stage8() {
     <div className="p-2 border rounded mb-2">
       <h2 className="font-bold">Stage 8</h2>
       <div className="flex space-x-2 mb-2">
-        <button className="bg-blue-500 text-white px-2 py-1" onClick={fetchPlan}>Get Plan</button>
-        <input className="border p-1 flex-1" value={input} onChange={e => setInput(e.target.value)} />
-        <button className="bg-green-500 text-white px-2 py-1" onClick={sendTelemetry}>Send Telemetry</button>
+        <button
+          className="bg-blue-500 text-white px-2 py-1 disabled:opacity-50"
+          onClick={fetchPlan}
+          disabled={isFetchingPlan}
+        >
+          {isFetchingPlan ? 'Fetching...' : 'Get Plan'}
+        </button>
+        <input
+          className="border p-1 flex-1"
+          value={input}
+          onChange={e => setInput(e.target.value)}
+        />
+        <button
+          className="bg-green-500 text-white px-2 py-1 disabled:opacity-50"
+          onClick={sendTelemetry}
+          disabled={isSendingTelemetry}
+        >
+          {isSendingTelemetry ? 'Sending...' : 'Send Telemetry'}
+        </button>
       </div>
       <ErrorMessage message={error} />
       {plan && <pre className="mt-2 bg-gray-100 p-2 text-sm">{JSON.stringify(plan, null, 2)}</pre>}


### PR DESCRIPTION
## Summary
- add isFetchingPlan and isSendingTelemetry state flags
- centralize loading/error handling in withLoading helper
- disable Stage8 buttons while operations are in progress and show status text

## Testing
- `npm test` (fails: Missing script: "test")


------
https://chatgpt.com/codex/tasks/task_e_689961fc5c40832fb586b37f6af0cfa2