### PR TITLE
feat: make StageResult generic

### DIFF
--- a/frontend/src/lib/StageResult.ts
+++ b/frontend/src/lib/StageResult.ts
@@ -1,5 +1,5 @@
-export interface StageResult {
+export interface StageResult<T = unknown> {
   stage: number;
   status: string;
-  data?: unknown;
+  data?: T;
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,23 +2,26 @@ import type { StageResult } from './StageResult'
 
 const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8000'
 
-export async function runStage(stage: number): Promise<StageResult> {
+export async function runStage<T = unknown>(stage: number): Promise<StageResult<T>> {
   const res = await fetch(`${API_BASE}/stage${stage}`)
   if (!res.ok) throw new Error('request failed')
   return res.json()
 }
 
-export async function getStagePath(stage: number, path: string): Promise<StageResult> {
+export async function getStagePath<T = unknown>(
+  stage: number,
+  path: string
+): Promise<StageResult<T>> {
   const res = await fetch(`${API_BASE}/stage${stage}/${path}`)
   if (!res.ok) throw new Error('request failed')
   return res.json()
 }
 
-export async function postStagePath(
+export async function postStagePath<T = unknown>(
   stage: number,
   path: string,
   data: unknown
-): Promise<StageResult> {
+): Promise<StageResult<T>> {
   const res = await fetch(`${API_BASE}/stage${stage}/${path}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- make StageResult interface generic with optional data type
- propagate generic typing through API helper functions

## Testing
- `npm test --prefix frontend` *(fails: Missing script "test")*
- `npm run build --prefix frontend`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app', 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_689961ff8274832f929e6e26acb6cf2b