### PR TITLE
feat: add fetchJson helper

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,28 +2,34 @@ import type { StageResult } from './StageResult'
 
 const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8000'
 
-export async function runStage(stage: number): Promise<StageResult> {
-  const res = await fetch(`${API_BASE}/stage${stage}`)
-  if (!res.ok) throw new Error('request failed')
-  return res.json()
+export async function fetchJson<T>(
+  input: RequestInfo | URL,
+  init?: RequestInit
+): Promise<T> {
+  const res = await fetch(input, init)
+  if (!res.ok) {
+    const message = await res.text()
+    throw new Error(`${res.status}: ${message}`)
+  }
+  return res.json() as Promise<T>
 }
 
-export async function getStagePath(stage: number, path: string): Promise<StageResult> {
-  const res = await fetch(`${API_BASE}/stage${stage}/${path}`)
-  if (!res.ok) throw new Error('request failed')
-  return res.json()
+export function runStage(stage: number): Promise<StageResult> {
+  return fetchJson<StageResult>(`${API_BASE}/stage${stage}`)
 }
 
-export async function postStagePath(
+export function getStagePath(stage: number, path: string): Promise<StageResult> {
+  return fetchJson<StageResult>(`${API_BASE}/stage${stage}/${path}`)
+}
+
+export function postStagePath(
   stage: number,
   path: string,
   data: unknown
 ): Promise<StageResult> {
-  const res = await fetch(`${API_BASE}/stage${stage}/${path}`, {
+  return fetchJson<StageResult>(`${API_BASE}/stage${stage}/${path}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   })
-  if (!res.ok) throw new Error('request failed')
-  return res.json()
 }


### PR DESCRIPTION
## Summary
- add reusable `fetchJson` for API requests with detailed error messages
- refactor stage APIs to use the helper and remove duplicate error checks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68996200fd18832f9221ccc6052d2672