### PR TITLE
feat: add fetchJson utility

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,19 +2,21 @@ import type { StageResult } from './StageResult'
 
 const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8000'
 
-export async function runStage<T = unknown>(stage: number): Promise<StageResult<T>> {
-  const res = await fetch(`${API_BASE}/stage${stage}`)
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, init)
   if (!res.ok) throw new Error('request failed')
   return res.json()
+}
+
+export async function runStage<T = unknown>(stage: number): Promise<StageResult<T>> {
+  return fetchJson(`${API_BASE}/stage${stage}`)
 }
 
 export async function getStagePath<T = unknown>(
   stage: number,
   path: string
 ): Promise<StageResult<T>> {
-  const res = await fetch(`${API_BASE}/stage${stage}/${path}`)
-  if (!res.ok) throw new Error('request failed')
-  return res.json()
+  return fetchJson(`${API_BASE}/stage${stage}/${path}`)
 }
 
 export async function postStagePath<T = unknown>(
@@ -22,11 +24,9 @@ export async function postStagePath<T = unknown>(
   path: string,
   data: unknown
 ): Promise<StageResult<T>> {
-  const res = await fetch(`${API_BASE}/stage${stage}/${path}`, {
+  return fetchJson(`${API_BASE}/stage${stage}/${path}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   })
-  if (!res.ok) throw new Error('request failed')
-  return res.json()
 }


### PR DESCRIPTION
## Summary
- add shared `fetchJson` helper
- refactor stage API methods to use `fetchJson`

## Testing
- `pytest` *(fails: No module named 'pydantic')*
- `npm test` *(fails: Missing script 'test')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689963935940832f8f440e5d892c2adb