### PR TITLE
feat: add stage0 ultra panel

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import Stage0 from './components/Stage0'
+import Stage0Panel from './components/Stage0Panel'
 import Stage1 from './components/Stage1'
 import Stage2 from './components/Stage2'
 import Stage3 from './components/Stage3'
@@ -15,7 +15,7 @@ export default function App() {
   return (
     <div className="p-4 space-y-2">
       <h1 className="text-3xl font-bold mb-4">God Mode Ultra Flow</h1>
-      <Stage0 />
+      <Stage0Panel />
       <Stage1 />
       <Stage2 />
       <Stage3 />

--- a/frontend/src/components/Stage0Panel.tsx
+++ b/frontend/src/components/Stage0Panel.tsx
@@ -1,0 +1,227 @@
+import { useState } from 'react'
+import ErrorMessage from './ErrorMessage'
+import {
+  buildStage0Context,
+  validateStage0Context,
+  uploadStage0Context,
+  getStage0Context,
+  listStage0Sources,
+  resolveStage0,
+  counterfactualStage0,
+  policyWatchStage0,
+} from '../lib/api'
+
+export default function Stage0Panel() {
+  const [lat, setLat] = useState('')
+  const [lon, setLon] = useState('')
+  const [contextId, setContextId] = useState('')
+  const [context, setContext] = useState<unknown | null>(null)
+  const [output, setOutput] = useState<unknown | null>(null)
+
+  const [query, setQuery] = useState('')
+  const [scenario, setScenario] = useState('')
+  const [policy, setPolicy] = useState('')
+
+  const [error, setError] = useState<string | null>(null)
+
+  const build = async () => {
+    try {
+      setError(null)
+      const res = await buildStage0Context({
+        location: { lat: parseFloat(lat), lon: parseFloat(lon) },
+      })
+      setContextId(res.context_id)
+      setContext(res.context)
+      setOutput(res)
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
+  }
+
+  const validate = async () => {
+    try {
+      if (!context) return
+      setError(null)
+      setOutput(await validateStage0Context(context))
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
+  }
+
+  const upload = async () => {
+    try {
+      if (!contextId) return
+      setError(null)
+      setOutput(await uploadStage0Context(contextId))
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
+  }
+
+  const fetchCtx = async () => {
+    try {
+      if (!contextId) return
+      setError(null)
+      const res = await getStage0Context(contextId)
+      setContext(res)
+      setOutput(res)
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
+  }
+
+  const sources = async () => {
+    try {
+      setError(null)
+      setOutput(await listStage0Sources())
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
+  }
+
+  const resolve = async () => {
+    try {
+      setError(null)
+      setOutput(await resolveStage0(query))
+      setQuery('')
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
+  }
+
+  const counterfactual = async () => {
+    try {
+      setError(null)
+      setOutput(await counterfactualStage0(scenario))
+      setScenario('')
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
+  }
+
+  const policyWatch = async () => {
+    try {
+      setError(null)
+      setOutput(await policyWatchStage0(policy))
+      setPolicy('')
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      setError(message)
+    }
+  }
+
+  return (
+    <div className="p-2 border rounded mb-2">
+      <h2 className="font-bold">Stage 0 (Ultra)</h2>
+      <div className="space-y-2">
+        <div className="flex space-x-2">
+          <input
+            className="border p-1 w-24"
+            placeholder="lat"
+            value={lat}
+            onChange={e => setLat(e.target.value)}
+          />
+          <input
+            className="border p-1 w-24"
+            placeholder="lon"
+            value={lon}
+            onChange={e => setLon(e.target.value)}
+          />
+          <button className="bg-blue-500 text-white px-2 py-1" onClick={build}>
+            Build Context
+          </button>
+          <button
+            className="bg-blue-500 text-white px-2 py-1"
+            onClick={validate}
+          >
+            Validate
+          </button>
+          <button
+            className="bg-blue-500 text-white px-2 py-1"
+            onClick={upload}
+          >
+            Upload
+          </button>
+        </div>
+        <div className="flex space-x-2">
+          <input
+            className="border p-1 flex-1"
+            placeholder="context id"
+            value={contextId}
+            onChange={e => setContextId(e.target.value)}
+          />
+          <button
+            className="bg-blue-500 text-white px-2 py-1"
+            onClick={fetchCtx}
+          >
+            Get Context
+          </button>
+          <button
+            className="bg-blue-500 text-white px-2 py-1"
+            onClick={sources}
+          >
+            List Sources
+          </button>
+        </div>
+        <div className="flex space-x-2">
+          <input
+            className="border p-1 flex-1"
+            placeholder="query"
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+          />
+          <button className="bg-blue-500 text-white px-2 py-1" onClick={resolve}>
+            Resolve
+          </button>
+        </div>
+        <div className="flex space-x-2">
+          <input
+            className="border p-1 flex-1"
+            placeholder="scenario"
+            value={scenario}
+            onChange={e => setScenario(e.target.value)}
+          />
+          <button
+            className="bg-blue-500 text-white px-2 py-1"
+            onClick={counterfactual}
+          >
+            Counterfactual
+          </button>
+        </div>
+        <div className="flex space-x-2">
+          <input
+            className="border p-1 flex-1"
+            placeholder="policy id"
+            value={policy}
+            onChange={e => setPolicy(e.target.value)}
+          />
+          <button
+            className="bg-blue-500 text-white px-2 py-1"
+            onClick={policyWatch}
+          >
+            Policy Watch
+          </button>
+        </div>
+        <ErrorMessage message={error} />
+        {context && (
+          <pre className="mt-2 bg-gray-100 p-2 text-sm">
+            {JSON.stringify(context, null, 2)}
+          </pre>
+        )}
+        {output && (
+          <pre className="mt-2 bg-gray-100 p-2 text-sm">
+            {JSON.stringify(output, null, 2)}
+          </pre>
+        )}
+      </div>
+    </div>
+  )
+}
+

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -30,3 +30,103 @@ export async function postStagePath<T = unknown>(
     body: JSON.stringify(data),
   })
 }
+
+// Stage 0 ultra endpoints -------------------------------------------------
+
+export interface Stage0Request {
+  location: { lat: number; lon: number }
+  climate_scenario?: string
+  lineage?: unknown
+}
+
+export interface BuildContextResponse {
+  context_id: string
+  context: unknown
+}
+
+export interface ValidateContextResponse {
+  valid: boolean
+  errors?: string[]
+}
+
+export interface UploadContextResponse {
+  uploaded: boolean
+}
+
+export interface ResolveResponse {
+  result: string
+}
+
+export interface CounterfactualResponse {
+  description: string
+}
+
+export interface PolicyWatchResponse {
+  status: string
+}
+
+export async function buildStage0Context(
+  req: Stage0Request
+): Promise<BuildContextResponse> {
+  return fetchJson(`${API_BASE}/stage0/context/build`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(req),
+  })
+}
+
+export async function validateStage0Context(
+  context: unknown
+): Promise<ValidateContextResponse> {
+  return fetchJson(`${API_BASE}/stage0/context/validate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ context }),
+  })
+}
+
+export async function uploadStage0Context(
+  context_id: string
+): Promise<UploadContextResponse> {
+  return fetchJson(`${API_BASE}/stage0/context/upload`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ context_id }),
+  })
+}
+
+export async function getStage0Context(context_id: string): Promise<unknown> {
+  return fetchJson(`${API_BASE}/stage0/context/${context_id}`)
+}
+
+export async function listStage0Sources(): Promise<string[]> {
+  return fetchJson(`${API_BASE}/stage0/sources`)
+}
+
+export async function resolveStage0(query: string): Promise<ResolveResponse> {
+  return fetchJson(`${API_BASE}/stage0/resolve`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query }),
+  })
+}
+
+export async function counterfactualStage0(
+  scenario: string
+): Promise<CounterfactualResponse> {
+  return fetchJson(`${API_BASE}/stage0/counterfactual`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ scenario }),
+  })
+}
+
+export async function policyWatchStage0(
+  policy_id: string
+): Promise<PolicyWatchResponse> {
+  return fetchJson(`${API_BASE}/stage0/policy/watch`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ policy_id }),
+  })
+}


### PR DESCRIPTION
## Summary
- add Stage 0 (Ultra) panel with context build, validation, upload, and query tools
- expose Stage 0 backend endpoints in api layer
- show Stage 0 (Ultra) panel in app

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run build` *(fails: Stage8.tsx compile error)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689969d07b34832fa43d872a1b16e033