### PR TITLE
Add Stage 0 run endpoint

### DIFF
--- a/backend/app/routers/stage0.py
+++ b/backend/app/routers/stage0.py
@@ -9,9 +9,18 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from app.models.context import SiteContext, Stage0Request
+from app.models.stage import StageResult
+from app.services import stage0
 from app.services.stage0_context import build_site_context
 
 router = APIRouter(prefix="/stage0", tags=["Stage 0"])
+
+
+@router.get("", response_model=StageResult)
+def run(lat: float = 0.0, lon: float = 0.0) -> StageResult:
+    """Run stage 0 context builder."""
+
+    return stage0.run(lat=lat, lon=lon)
 
 # In-memory store for built contexts
 _CONTEXTS: Dict[str, SiteContext] = {}


### PR DESCRIPTION
## Summary
- expose Stage 0 run endpoint returning StageResult
- add optional lat/lon query parameters

## Testing
- `pytest -q` *(fails: test_validate_rejects_self_intersection, test_counterfactual_changes_risks, test_resolve_updates_context)*

------
https://chatgpt.com/codex/tasks/task_e_68996d371f18832f9122e41d5ea6e3e7