### PR TITLE
Use default factory for audit items

### DIFF
--- a/backend/app/models/context.py
+++ b/backend/app/models/context.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import List, Optional, Union
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class LatLon(BaseModel):
@@ -85,7 +85,7 @@ class ExplainItem(BaseModel):
 class AuditBlock(BaseModel):
     """Set of explanatory items with optional versioning."""
 
-    items: List[ExplainItem] = []
+    items: List[ExplainItem] = Field(default_factory=list)
     version: Optional[str] = None
 
 


### PR DESCRIPTION
## Summary
- avoid mutable default for audit items by using `Field(default_factory=list)`

## Testing
- `pip install .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689971734614832f9d069b2b6e977a64