### PR TITLE
fix: switch frontend configs to CommonJS

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,6 @@
-export default {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
   },
-}
+};

--- a/frontend/src/components/Stage8.tsx
+++ b/frontend/src/components/Stage8.tsx
@@ -11,7 +11,7 @@ export default function Stage8() {
   const [isFetchingPlan, setIsFetchingPlan] = useState(false)
   const [isSendingTelemetry, setIsSendingTelemetry] = useState(false)
 
-  const withLoading = async <T>(
+  const withLoading = async <T,>(
     action: () => Promise<T>,
     setLoading: (flag: boolean) => void
   ) => {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,8 +1,8 @@
 /** @type {import('tailwindcss').Config} */
-export default {
+module.exports = {
   content: ["./index.html", "./src/**/*.{ts,tsx}"],
   theme: {
     extend: {},
   },
   plugins: [],
-}
+};


### PR DESCRIPTION
## Summary
- switch Tailwind and PostCSS configuration files to use CommonJS exports
- adjust Stage8 generic helper so `npm run build` succeeds

## Testing
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899722ea91c832fbf39dd85e114acc5