### PR TITLE
Include context ID in Stage0 API requests

### DIFF
--- a/frontend/src/components/Stage0Panel.tsx
+++ b/frontend/src/components/Stage0Panel.tsx
@@ -87,7 +87,8 @@ export default function Stage0Panel() {
   const resolve = async () => {
     try {
       setError(null)
-      setOutput(await resolveStage0(query))
+      if (!contextId) return
+      setOutput(await resolveStage0(contextId, query))
       setQuery('')
     } catch (e) {
       const message = e instanceof Error ? e.message : 'Unknown error'
@@ -98,7 +99,8 @@ export default function Stage0Panel() {
   const counterfactual = async () => {
     try {
       setError(null)
-      setOutput(await counterfactualStage0(scenario))
+      if (!contextId) return
+      setOutput(await counterfactualStage0(contextId, scenario))
       setScenario('')
     } catch (e) {
       const message = e instanceof Error ? e.message : 'Unknown error'

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -103,21 +103,25 @@ export async function listStage0Sources(): Promise<string[]> {
   return fetchJson(`${API_BASE}/stage0/sources`)
 }
 
-export async function resolveStage0(query: string): Promise<ResolveResponse> {
+export async function resolveStage0(
+  context_id: string,
+  query: string
+): Promise<ResolveResponse> {
   return fetchJson(`${API_BASE}/stage0/resolve`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ query }),
+    body: JSON.stringify({ context_id, query }),
   })
 }
 
 export async function counterfactualStage0(
+  context_id: string,
   scenario: string
 ): Promise<CounterfactualResponse> {
   return fetchJson(`${API_BASE}/stage0/counterfactual`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ scenario }),
+    body: JSON.stringify({ context_id, scenario }),
   })
 }
 


### PR DESCRIPTION
## Summary
- Include `context_id` in Stage0 resolve and counterfactual API calls
- Pass `contextId` from Stage0Panel to resolve and counterfactual helpers

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Engineering/package.json')*
- `npm test` *(frontend) *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6899732652bc832f9b28b0c0865bb4e4