### PR TITLE
Add basic agent orchestrator and generation endpoint

### DIFF
--- a/backend/app/ai_agents/orchestrator.py
+++ b/backend/app/ai_agents/orchestrator.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Dict, List, Protocol
+from uuid import uuid4
+
+from pydantic import BaseModel
+
+from app.models import SiteContext, Weights, VariantOut
+
+
+@dataclass
+class Proposal:
+    type: str
+    data: Dict[str, str]
+
+
+@dataclass
+class Candidate:
+    id: str
+    label: str
+    metadata: Dict[str, str]
+
+
+class DesignState(BaseModel):
+    site: SiteContext | None = None
+    seed: int = 0
+    candidates: List[Candidate] = []
+
+
+class Agent(Protocol):
+    name: str
+
+    def propose(self, state: DesignState) -> Proposal:
+        ...
+
+
+class AestheticsAgent:
+    name = "aesthetics"
+
+    def propose(self, state: DesignState) -> Proposal:
+        color = random.choice(["red", "blue", "green"])
+        return Proposal(type=self.name, data={"color": color})
+
+
+class SustainabilityAgent:
+    name = "sustainability"
+
+    def propose(self, state: DesignState) -> Proposal:
+        system = random.choice(["solar", "geothermal"])
+        return Proposal(type=self.name, data={"energy": system})
+
+
+class CostAgent:
+    name = "cost"
+
+    def propose(self, state: DesignState) -> Proposal:
+        level = random.choice(["low", "medium", "high"])
+        return Proposal(type=self.name, data={"cost_level": level})
+
+
+class AccessibilityAgent:
+    name = "accessibility"
+
+    def propose(self, state: DesignState) -> Proposal:
+        feature = random.choice(["ramp", "elevator"])
+        return Proposal(type=self.name, data={"feature": feature})
+
+
+class StructuralAgent:
+    name = "structural"
+
+    def propose(self, state: DesignState) -> Proposal:
+        system = random.choice(["steel", "timber"])
+        return Proposal(type=self.name, data={"structure": system})
+
+
+class Synthesizer:
+    @staticmethod
+    def merge(proposals: List[Proposal], state: DesignState) -> Candidate:
+        meta: Dict[str, str] = {}
+        for p in proposals:
+            meta.update(p.data)
+        label = "_".join(f"{k}:{v}" for k, v in meta.items())
+        return Candidate(id=str(uuid4()), label=label, metadata=meta)
+
+
+class Critic:
+    @staticmethod
+    def review(candidate: Candidate, state: DesignState) -> List[str]:
+        return []
+
+
+def score_candidate(candidate: Candidate, weights: Weights) -> Dict[str, float]:
+    # simple random scores for demonstration
+    scores = {
+        "aesthetic": random.random(),
+        "sustainability": random.random(),
+        "cost": random.random(),
+        "accessibility": random.random(),
+        "emotion": random.random(),
+    }
+    scores["composite"] = sum(scores[k] * getattr(weights, k) for k in weights.model_fields)
+    return scores
+
+
+def run_generation(n: int, weights: Weights) -> List[VariantOut]:
+    state = DesignState()
+    agents: List[Agent] = [
+        AestheticsAgent(),
+        SustainabilityAgent(),
+        CostAgent(),
+        AccessibilityAgent(),
+        StructuralAgent(),
+    ]
+
+    variants: List[VariantOut] = []
+    for _ in range(n):
+        proposals = [a.propose(state) for a in agents]
+        candidate = Synthesizer.merge(proposals, state)
+        scores = score_candidate(candidate, weights)
+        variant = VariantOut(
+            id=candidate.id,
+            label=candidate.label,
+            metadata=candidate.metadata,
+            score=scores,
+            rank=0,
+            assets=[],
+        )
+        variants.append(variant)
+    # assign ranks based on composite score
+    variants.sort(key=lambda v: v.score.get("composite", 0), reverse=True)
+    for idx, v in enumerate(variants, start=1):
+        v.rank = idx
+    return variants

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -14,6 +14,7 @@ from .context import (
     Stage0Request,
     SiteContext,
 )
+from .generation import Weights, VariantAsset, VariantOut
 
 __all__ = [
     "StageResult",
@@ -30,4 +31,7 @@ __all__ = [
     "AuditBlock",
     "Stage0Request",
     "SiteContext",
+    "Weights",
+    "VariantAsset",
+    "VariantOut",
 ]

--- a/backend/app/models/generation.py
+++ b/backend/app/models/generation.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class Weights(BaseModel):
+    aesthetic: float = 0.25
+    sustainability: float = 0.25
+    cost: float = 0.20
+    accessibility: float = 0.15
+    emotion: float = 0.15
+
+
+class VariantAsset(BaseModel):
+    type: Literal['render', 'model', 'pdf', 'json']
+    path: str
+    signed_url: Optional[str] = None
+
+
+class VariantOut(BaseModel):
+    id: UUID
+    label: str
+    metadata: Dict[str, Any] | None = None
+    score: Dict[str, float] | None = None
+    rank: int
+    assets: list[VariantAsset] = []
+

--- a/backend/app/routers/stage1.py
+++ b/backend/app/routers/stage1.py
@@ -1,19 +1,21 @@
 """API router for Stage 1 variant generation endpoints."""
 
 from fastapi import APIRouter
+from pydantic import BaseModel
 
-from app.models.stage import StageResult
+from app.models import StageResult, Weights
 from app.services import stage1
 
 router = APIRouter(prefix="/stage1", tags=["Stage 1"])
 
 
-@router.get("", response_model=StageResult)
-def run() -> StageResult:
-    """Generate design variants for stage 1.
+class GenerateRequest(BaseModel):
+    n_variants: int = 3
+    weights: Weights | None = None
 
-    Returns:
-        StageResult: Summary of generated variants.
-    """
 
-    return stage1.run()
+@router.post("/generate", response_model=StageResult)
+def generate(req: GenerateRequest) -> StageResult:
+    """Generate design variants for stage 1."""
+
+    return stage1.run(req.n_variants, req.weights)

--- a/backend/app/services/stage1.py
+++ b/backend/app/services/stage1.py
@@ -1,15 +1,13 @@
 """Service functions for Stage 1 variant generation."""
 
-from app.models.stage import StageResult
-from app.ai_agents.negotiator import negotiator
+from app.models import StageResult, Weights
+from app.ai_agents.orchestrator import run_generation
 
 
-def run() -> StageResult:
-    """Generate combinatorial design variants.
+def run(n_variants: int = 3, weights: Weights | None = None) -> StageResult:
+    """Generate design variants using simple agent orchestration."""
 
-    Returns:
-        StageResult: Details about the produced design variants.
-    """
-
-    variants = negotiator.generate_variants()
-    return StageResult(stage=1, status="variants generated", data={"variants": variants})
+    weights = weights or Weights()
+    variants = run_generation(n_variants, weights)
+    data = {"variants": [v.model_dump() for v in variants]}
+    return StageResult(stage=1, status="variants generated", data=data)

--- a/backend/tests/test_orchestrator.py
+++ b/backend/tests/test_orchestrator.py
@@ -1,0 +1,10 @@
+from app.ai_agents.orchestrator import run_generation
+from app.models import Weights
+
+
+def test_run_generation_returns_ranked_variants():
+    weights = Weights()
+    variants = run_generation(5, weights)
+    assert len(variants) == 5
+    scores = [v.score["composite"] for v in variants]
+    assert scores == sorted(scores, reverse=True)

--- a/backend/tests/test_stages0_7.py
+++ b/backend/tests/test_stages0_7.py
@@ -15,9 +15,11 @@ def test_stage0_build_context():
 
 
 def test_stage1_endpoint():
-    res = client.get("/stage1")
+    res = client.post("/stage1/generate", json={"n_variants": 2})
     assert res.status_code == 200
-    assert res.json()["stage"] == 1
+    body = res.json()
+    assert body["stage"] == 1
+    assert len(body["data"]["variants"]) == 2
 
 
 def test_stage2_endpoint():


### PR DESCRIPTION
## Summary
- implement simple multi-agent orchestrator that proposes features and scores variants
- add shared models for weights and variant assets
- expose POST /stage1/generate endpoint and test coverage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899b0e4258c832f98f5ea6242609391