### PR TITLE
Add SQLAlchemy models and migration setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ __pycache__/
 *.pyd
 env/
 venv/
+*.egg-info/
+*.db
 
 # Node
 node_modules/

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = migrations
+sqlalchemy.url = sqlite:///./app.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)s %(name)s %(message)s

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -5,6 +5,7 @@ class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
 
     app_name: str = "God Mode Ultra Flow"
+    database_url: str = "sqlite:///./app.db"
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -1,0 +1,2 @@
+from .models import Base, Project, Job, Variant, Feedback, EmotionEvent  # noqa: F401
+from .session import SessionLocal, get_db  # noqa: F401

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from sqlalchemy import Column, DateTime, Float, ForeignKey, Integer, JSON, String, Text, func
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+
+class Project(Base):
+    __tablename__ = "projects"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    description = Column(Text, nullable=True)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+
+    jobs = relationship("Job", back_populates="project", cascade="all, delete-orphan")
+
+
+class Job(Base):
+    __tablename__ = "jobs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    project_id = Column(ForeignKey("projects.id"), nullable=False)
+    input_data = Column(JSON, nullable=True)
+    status = Column(String, nullable=False, server_default="pending")
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    project = relationship("Project", back_populates="jobs")
+    variants = relationship("Variant", back_populates="job", cascade="all, delete-orphan")
+
+
+class Variant(Base):
+    __tablename__ = "variants"
+
+    id = Column(Integer, primary_key=True, index=True)
+    job_id = Column(ForeignKey("jobs.id"), nullable=False)
+    content = Column(JSON, nullable=True)
+    score = Column(Float, nullable=True)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+
+    job = relationship("Job", back_populates="variants")
+    feedback = relationship("Feedback", back_populates="variant", cascade="all, delete-orphan")
+
+
+class Feedback(Base):
+    __tablename__ = "feedback"
+
+    id = Column(Integer, primary_key=True, index=True)
+    variant_id = Column(ForeignKey("variants.id"), nullable=False)
+    rating = Column(Integer, nullable=True)
+    comments = Column(Text, nullable=True)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+
+    variant = relationship("Variant", back_populates="feedback")
+    emotion_events = relationship("EmotionEvent", back_populates="feedback", cascade="all, delete-orphan")
+
+
+class EmotionEvent(Base):
+    __tablename__ = "emotion_events"
+
+    id = Column(Integer, primary_key=True, index=True)
+    feedback_id = Column(ForeignKey("feedback.id"), nullable=False)
+    emotion = Column(String, nullable=False)
+    intensity = Column(Float, nullable=False)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+
+    feedback = relationship("Feedback", back_populates="emotion_events")

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.config import settings
+
+engine = create_engine(settings.database_url, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,8 @@
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
+from sqlalchemy.orm import Session
+
 from app.core.config import settings
+from app.db.session import get_db
 from app.routers import (
     stage0,
     stage1,
@@ -32,5 +35,5 @@ app.include_router(stage11.router)
 
 
 @app.get("/")
-async def root():
+async def root(db: Session = Depends(get_db)):
     return {"message": f"{settings.app_name} API"}

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+from logging.config import fileConfig
+
+# ensure app package on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from app.core.config import settings
+from app.db.models import Base
+
+config = context.config
+config.set_main_option("sqlalchemy.url", settings.database_url)
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/migrations/versions/0001_initial.py
+++ b/backend/migrations/versions/0001_initial.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "projects",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_table(
+        "jobs",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("project_id", sa.Integer(), sa.ForeignKey("projects.id"), nullable=False),
+        sa.Column("input_data", sa.JSON(), nullable=True),
+        sa.Column("status", sa.String(), server_default="pending", nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_table(
+        "variants",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("job_id", sa.Integer(), sa.ForeignKey("jobs.id"), nullable=False),
+        sa.Column("content", sa.JSON(), nullable=True),
+        sa.Column("score", sa.Float(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_table(
+        "feedback",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("variant_id", sa.Integer(), sa.ForeignKey("variants.id"), nullable=False),
+        sa.Column("rating", sa.Integer(), nullable=True),
+        sa.Column("comments", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_table(
+        "emotion_events",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("feedback_id", sa.Integer(), sa.ForeignKey("feedback.id"), nullable=False),
+        sa.Column("emotion", sa.String(), nullable=False),
+        sa.Column("intensity", sa.Float(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("emotion_events")
+    op.drop_table("feedback")
+    op.drop_table("variants")
+    op.drop_table("jobs")
+    op.drop_table("projects")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,7 +8,10 @@ dependencies = [
     "httpx",
     "pytest",
     "pydantic-settings>=2.0.0",
-    "shapely"
+    "shapely",
+    "sqlalchemy>=2.0",
+    "alembic",
+    "python-multipart"
 ]
 
 [build-system]
@@ -19,3 +22,6 @@ build-backend = "setuptools.build_meta"
 pythonpath = [
     "."
 ]
+
+[tool.setuptools.packages.find]
+exclude = ["migrations"]


### PR DESCRIPTION
## Summary
- define SQLAlchemy ORM models for projects, jobs, variants, feedback, and emotion events
- configure database session utilities and wire FastAPI to use them
- setup Alembic with initial migration and add database dependencies

## Testing
- `alembic upgrade head`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899b5d2d91c832fa056949b9a1d7e8e