### PR TITLE
Add v1 generation API with JWT auth

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -6,6 +6,9 @@ class Settings(BaseSettings):
 
     app_name: str = "God Mode Ultra Flow"
     database_url: str = "sqlite:///./app.db"
+    secret_key: str = "change-me"
+    jwt_algorithm: str = "HS256"
+    cors_origins: list[str] = ["*"]
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import Depends, FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
@@ -16,9 +17,18 @@ from app.routers import (
     stage9,
     stage10,
     stage11,
+    v1,
 )
 
 app = FastAPI(title=settings.app_name)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.cors_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 app.include_router(stage0.router)
 app.include_router(stage1.router)
@@ -32,6 +42,7 @@ app.include_router(stage8.router)
 app.include_router(stage9.router)
 app.include_router(stage10.router)
 app.include_router(stage11.router)
+app.include_router(v1.router)
 
 
 @app.get("/")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -14,7 +14,16 @@ from .context import (
     Stage0Request,
     SiteContext,
 )
-from .generation import Weights, VariantAsset, VariantOut
+from .generation import (
+    Weights,
+    VariantAsset,
+    VariantOut,
+    GenerateRequest,
+    JobOut,
+    JobEvent,
+    JobStatus,
+    FeedbackIn,
+)
 
 __all__ = [
     "StageResult",
@@ -34,4 +43,9 @@ __all__ = [
     "Weights",
     "VariantAsset",
     "VariantOut",
+    "GenerateRequest",
+    "JobOut",
+    "JobEvent",
+    "JobStatus",
+    "FeedbackIn",
 ]

--- a/backend/app/models/generation.py
+++ b/backend/app/models/generation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Literal, Optional
 from uuid import UUID
+from enum import Enum
 
 from pydantic import BaseModel
 
@@ -27,4 +28,32 @@ class VariantOut(BaseModel):
     score: Dict[str, float] | None = None
     rank: int
     assets: list[VariantAsset] = []
+
+
+class GenerateRequest(BaseModel):
+    n: int = 3
+    weights: Weights = Weights()
+
+
+class JobStatus(str, Enum):
+    queued = "queued"
+    completed = "completed"
+    failed = "failed"
+
+
+class JobOut(BaseModel):
+    id: UUID
+    status: JobStatus
+    variants: list[VariantOut] | None = None
+    error: Optional[str] = None
+
+
+class JobEvent(BaseModel):
+    type: Literal["status", "variant"]
+    data: Dict[str, Any]
+
+
+class FeedbackIn(BaseModel):
+    rating: int
+    comment: Optional[str] = None
 

--- a/backend/app/routers/v1.py
+++ b/backend/app/routers/v1.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import uuid
+from typing import Dict, List
+
+import jwt
+from fastapi import APIRouter, Depends, HTTPException, WebSocket
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from app.ai_agents.orchestrator import run_generation
+from app.core.config import settings
+from app.models import (
+    FeedbackIn,
+    GenerateRequest,
+    JobEvent,
+    JobOut,
+    JobStatus,
+    VariantOut,
+)
+
+router = APIRouter(prefix="/v1", tags=["v1"])
+
+security = HTTPBearer()
+
+JOBS: Dict[str, JobOut] = {}
+VARIANTS: Dict[str, VariantOut] = {}
+FEEDBACK: Dict[str, List[FeedbackIn]] = {}
+
+
+def verify_token(credentials: HTTPAuthorizationCredentials = Depends(security)) -> Dict:
+    token = credentials.credentials
+    try:
+        return jwt.decode(token, settings.secret_key, algorithms=[settings.jwt_algorithm])
+    except Exception as exc:  # pragma: no cover
+        raise HTTPException(status_code=401, detail="Invalid token") from exc
+
+
+@router.post("/generate", response_model=JobOut)
+async def generate(req: GenerateRequest, credentials: HTTPAuthorizationCredentials = Depends(security)) -> JobOut:
+    verify_token(credentials)
+    variants = run_generation(req.n, req.weights)
+    job_id = uuid.uuid4()
+    for v in variants:
+        VARIANTS[str(v.id)] = v
+    job = JobOut(id=job_id, status=JobStatus.completed, variants=variants)
+    JOBS[str(job_id)] = job
+    return job
+
+
+@router.get("/jobs/{job_id}", response_model=JobOut)
+async def get_job(job_id: uuid.UUID, credentials: HTTPAuthorizationCredentials = Depends(security)) -> JobOut:
+    verify_token(credentials)
+    job = JOBS.get(str(job_id))
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return job
+
+
+@router.websocket("/jobs/{job_id}/events")
+async def job_events(websocket: WebSocket, job_id: uuid.UUID, token: str):
+    try:
+        jwt.decode(token, settings.secret_key, algorithms=[settings.jwt_algorithm])
+    except Exception:
+        await websocket.close(code=1008)
+        return
+    await websocket.accept()
+    job = JOBS.get(str(job_id))
+    if not job:
+        await websocket.close(code=1008)
+        return
+    await websocket.send_json(JobEvent(type="status", data={"status": job.status}).model_dump())
+    for variant in job.variants or []:
+        await websocket.send_json(JobEvent(type="variant", data=variant.model_dump()).model_dump())
+    await websocket.close()
+
+
+@router.get("/variants/{variant_id}", response_model=VariantOut)
+async def get_variant(variant_id: uuid.UUID, credentials: HTTPAuthorizationCredentials = Depends(security)) -> VariantOut:
+    verify_token(credentials)
+    variant = VARIANTS.get(str(variant_id))
+    if not variant:
+        raise HTTPException(status_code=404, detail="Variant not found")
+    return variant
+
+
+@router.post("/feedback/{variant_id}")
+async def submit_feedback(
+    variant_id: uuid.UUID,
+    fb: FeedbackIn,
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> Dict[str, str]:
+    verify_token(credentials)
+    if str(variant_id) not in VARIANTS:
+        raise HTTPException(status_code=404, detail="Variant not found")
+    FEEDBACK.setdefault(str(variant_id), []).append(fb)
+    return {"status": "ok"}

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,7 +11,8 @@ dependencies = [
     "shapely",
     "sqlalchemy>=2.0",
     "alembic",
-    "python-multipart"
+    "python-multipart",
+    "pyjwt"
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- add v1 generation router with job, variant and feedback endpoints
- define generation schemas for job workflow
- configure JWT bearer auth and CORS settings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899b8af8f14832fa5aff10312e52daf