### PR TITLE
feat: async orchestrator and candidate persistence

### DIFF
--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -67,3 +67,40 @@ class EmotionEvent(Base):
     created_at = Column(DateTime, server_default=func.now(), nullable=False)
 
     feedback = relationship("Feedback", back_populates="emotion_events")
+
+
+class Candidate(Base):
+    __tablename__ = "candidates"
+
+    id = Column(String, primary_key=True, index=True)
+    label = Column(String, nullable=False)
+    meta = Column("metadata", JSON, nullable=True)
+    scores = Column(JSON, nullable=True)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+
+    feedback = relationship("CandidateFeedback", back_populates="candidate", cascade="all, delete-orphan")
+
+
+class CandidateFeedback(Base):
+    __tablename__ = "candidate_feedback"
+
+    id = Column(Integer, primary_key=True, index=True)
+    candidate_id = Column(ForeignKey("candidates.id"), nullable=False)
+    rating = Column(Integer, nullable=True)
+    comments = Column(Text, nullable=True)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+
+    candidate = relationship("Candidate", back_populates="feedback")
+    emotion_events = relationship("CandidateEmotionEvent", back_populates="feedback", cascade="all, delete-orphan")
+
+
+class CandidateEmotionEvent(Base):
+    __tablename__ = "candidate_emotion_events"
+
+    id = Column(Integer, primary_key=True, index=True)
+    feedback_id = Column(ForeignKey("candidate_feedback.id"), nullable=False)
+    emotion = Column(String, nullable=False)
+    intensity = Column(Float, nullable=False)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+
+    feedback = relationship("CandidateFeedback", back_populates="emotion_events")

--- a/backend/migrations/versions/0002_candidates.py
+++ b/backend/migrations/versions/0002_candidates.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "candidates",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("label", sa.String(), nullable=False),
+        sa.Column("metadata", sa.JSON(), nullable=True),
+        sa.Column("scores", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_table(
+        "candidate_feedback",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("candidate_id", sa.String(), sa.ForeignKey("candidates.id"), nullable=False),
+        sa.Column("rating", sa.Integer(), nullable=True),
+        sa.Column("comments", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_table(
+        "candidate_emotion_events",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("feedback_id", sa.Integer(), sa.ForeignKey("candidate_feedback.id"), nullable=False),
+        sa.Column("emotion", sa.String(), nullable=False),
+        sa.Column("intensity", sa.Float(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("candidate_emotion_events")
+    op.drop_table("candidate_feedback")
+    op.drop_table("candidates")


### PR DESCRIPTION
## Summary
- track design state with context, feedback and emotion stats
- run async agent proposals in round loop and persist candidates
- store candidate feedback and emotions in new tables

## Testing
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899bb1c33cc832f981f7001b1a40673